### PR TITLE
feat: Add display mode for USB screen

### DIFF
--- a/butler/usb_screen.py
+++ b/butler/usb_screen.py
@@ -1,0 +1,12 @@
+class USBScreen:
+    """
+    A mock class to simulate the display on a USB drive.
+    In a real-world scenario, this class would interface with the hardware
+    of the screen on the USB drive.
+    """
+    def display(self, message):
+        """
+        Displays a message on the USB screen.
+        For this mock version, it just prints to the console.
+        """
+        print(f"[USB SCREEN] {message}")

--- a/logs/application.json
+++ b/logs/application.json
@@ -160,3 +160,154 @@ MemoPlugin 初始化完成
 扫描模块: plugin.write_file
 插件加载完成，共 1 个插件
 Failed to launch ArchiverApp: Too early to Archiver could not find a master window.: no default root window
+开始加载插件包: plugin
+扫描模块: plugin.BingSearchPlugin
+扫描模块: plugin.CountdownPlugin
+扫描模块: plugin.FileSearchPlugin
+扫描模块: plugin.GlobalFileSearchPlugin
+扫描模块: plugin.JokePlugin
+扫描模块: plugin.MemoPlugin
+MemoPlugin 初始化完成
+成功加载插件: MemoPlugin
+扫描模块: plugin.NotepadPlugin
+扫描模块: plugin.PluginManager
+扫描模块: plugin.SearchPlugin
+扫描模块: plugin.TimePlugin
+扫描模块: plugin.TodoPlugin
+扫描模块: plugin.abstract_plugin
+扫描模块: plugin.add_long_memory
+扫描模块: plugin.clear_recent_memory
+扫描模块: plugin.download_url
+扫描模块: plugin.plugin
+开始加载插件包: plugin
+扫描模块: plugin.BingSearchPlugin
+扫描模块: plugin.CountdownPlugin
+扫描模块: plugin.FileSearchPlugin
+扫描模块: plugin.GlobalFileSearchPlugin
+扫描模块: plugin.JokePlugin
+扫描模块: plugin.MemoPlugin
+MemoPlugin 初始化完成
+成功加载插件: MemoPlugin
+扫描模块: plugin.NotepadPlugin
+扫描模块: plugin.PluginManager
+扫描模块: plugin.SearchPlugin
+扫描模块: plugin.TimePlugin
+扫描模块: plugin.TodoPlugin
+扫描模块: plugin.abstract_plugin
+扫描模块: plugin.add_long_memory
+扫描模块: plugin.clear_recent_memory
+扫描模块: plugin.download_url
+扫描模块: plugin.plugin
+扫描模块: plugin.plugin_interface
+扫描模块: plugin.read_file
+扫描模块: plugin.write_file
+插件加载完成，共 1 个插件
+已加载插件: ['MemoPlugin']
+扫描模块: plugin.plugin_interface
+扫描模块: plugin.read_file
+扫描模块: plugin.write_file
+插件加载完成，共 1 个插件
+Failed to initialize DeepSeekLongMemory (DeepSeek API key not found.). Falling back to SQLiteLongMemory.
+初始化 SQLiteLongMemory 失败: unable to open database file
+开始加载插件包: plugin
+扫描模块: plugin.BingSearchPlugin
+扫描模块: plugin.CountdownPlugin
+扫描模块: plugin.FileSearchPlugin
+扫描模块: plugin.GlobalFileSearchPlugin
+扫描模块: plugin.JokePlugin
+扫描模块: plugin.MemoPlugin
+MemoPlugin 初始化完成
+成功加载插件: MemoPlugin
+扫描模块: plugin.NotepadPlugin
+扫描模块: plugin.PluginManager
+扫描模块: plugin.SearchPlugin
+扫描模块: plugin.TimePlugin
+扫描模块: plugin.TodoPlugin
+扫描模块: plugin.abstract_plugin
+扫描模块: plugin.add_long_memory
+扫描模块: plugin.clear_recent_memory
+扫描模块: plugin.download_url
+扫描模块: plugin.plugin
+开始加载插件包: plugin
+扫描模块: plugin.BingSearchPlugin
+扫描模块: plugin.CountdownPlugin
+扫描模块: plugin.FileSearchPlugin
+扫描模块: plugin.GlobalFileSearchPlugin
+扫描模块: plugin.JokePlugin
+扫描模块: plugin.MemoPlugin
+MemoPlugin 初始化完成
+成功加载插件: MemoPlugin
+扫描模块: plugin.NotepadPlugin
+扫描模块: plugin.PluginManager
+扫描模块: plugin.SearchPlugin
+扫描模块: plugin.TimePlugin
+扫描模块: plugin.TodoPlugin
+扫描模块: plugin.abstract_plugin
+扫描模块: plugin.add_long_memory
+扫描模块: plugin.clear_recent_memory
+扫描模块: plugin.download_url
+扫描模块: plugin.plugin
+扫描模块: plugin.plugin_interface
+扫描模块: plugin.read_file
+扫描模块: plugin.write_file
+插件加载完成，共 1 个插件
+已加载插件: ['MemoPlugin']
+扫描模块: plugin.plugin_interface
+扫描模块: plugin.read_file
+扫描模块: plugin.write_file
+插件加载完成，共 1 个插件
+Failed to initialize DeepSeekLongMemory (DeepSeek API key not found.). Falling back to SQLiteLongMemory.
+初始化 SQLiteLongMemory...
+SQLiteLongMemory 初始化成功
+SQLiteLongMemory initialized as a fallback.
+开始加载插件包: plugin
+扫描模块: plugin.BingSearchPlugin
+扫描模块: plugin.CountdownPlugin
+扫描模块: plugin.FileSearchPlugin
+扫描模块: plugin.GlobalFileSearchPlugin
+扫描模块: plugin.JokePlugin
+扫描模块: plugin.MemoPlugin
+MemoPlugin 初始化完成
+成功加载插件: MemoPlugin
+扫描模块: plugin.NotepadPlugin
+扫描模块: plugin.PluginManager
+扫描模块: plugin.SearchPlugin
+扫描模块: plugin.TimePlugin
+扫描模块: plugin.TodoPlugin
+扫描模块: plugin.abstract_plugin
+扫描模块: plugin.add_long_memory
+扫描模块: plugin.clear_recent_memory
+扫描模块: plugin.download_url
+扫描模块: plugin.plugin
+开始加载插件包: plugin
+扫描模块: plugin.BingSearchPlugin
+扫描模块: plugin.CountdownPlugin
+扫描模块: plugin.FileSearchPlugin
+扫描模块: plugin.GlobalFileSearchPlugin
+扫描模块: plugin.JokePlugin
+扫描模块: plugin.MemoPlugin
+MemoPlugin 初始化完成
+成功加载插件: MemoPlugin
+扫描模块: plugin.NotepadPlugin
+扫描模块: plugin.PluginManager
+扫描模块: plugin.SearchPlugin
+扫描模块: plugin.TimePlugin
+扫描模块: plugin.TodoPlugin
+扫描模块: plugin.abstract_plugin
+扫描模块: plugin.add_long_memory
+扫描模块: plugin.clear_recent_memory
+扫描模块: plugin.download_url
+扫描模块: plugin.plugin
+扫描模块: plugin.plugin_interface
+扫描模块: plugin.read_file
+扫描模块: plugin.write_file
+插件加载完成，共 1 个插件
+已加载插件: ['MemoPlugin']
+扫描模块: plugin.plugin_interface
+扫描模块: plugin.read_file
+扫描模块: plugin.write_file
+插件加载完成，共 1 个插件
+Failed to initialize DeepSeekLongMemory (DeepSeek API key not found.). Falling back to SQLiteLongMemory.
+初始化 SQLiteLongMemory...
+SQLiteLongMemory 初始化成功
+SQLiteLongMemory initialized as a fallback.


### PR DESCRIPTION
This commit introduces a new feature that allows the user to select the output display for the application. It simulates a scenario where a USB drive has its own screen.

The user can now choose between three display modes:
- Host: Output is displayed on the main application GUI.
- USB: Output is displayed on the simulated USB screen (console output with a prefix).
- Both: Output is displayed on both the GUI and the USB screen.

Changes include:
- A new `USBScreen` class to simulate the USB screen.
- A "Display Mode" selector with radio buttons in the `CommandPanel`.
- Logic in the `Jarvis` class to manage the display mode and route output accordingly.
- A `/display` command for changing the mode in headless environments.