### PR TITLE
Integrate npx skills management into Butler CLI and UI

### DIFF
--- a/.agents/skills/find-skills/SKILL.md
+++ b/.agents/skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/butler_cli.py
+++ b/butler_cli.py
@@ -100,6 +100,11 @@ def main():
     file_parser.add_argument("--path", required=True, help="目标路径")
     file_parser.add_argument("--content", help="写入的内容 (仅用于 create)")
 
+    # 12. 技能管理 (Skills) - 包装 npx skills
+    skills_parser = subparsers.add_parser("skills", help="技能库管理 (集成 npx skills)")
+    skills_parser.add_argument("op", choices=["add", "remove", "list", "find"], help="操作类型")
+    skills_parser.add_argument("extra_args", nargs=argparse.REMAINDER, help="npx skills 的原生参数")
+
     # --- 动态加载自定义技能 ---
     try:
         from butler.core.skill_manager import SkillManager
@@ -217,6 +222,12 @@ def main():
                     for item in items: print(f"  - {item}")
                 else:
                     print(f"❌ {items}")
+
+        elif args.command == "skills":
+            import subprocess
+            cmd = ["npx", "-y", "skills", args.op] + args.extra_args
+            print(f"🚀 执行命令: {' '.join(cmd)}")
+            subprocess.run(cmd)
 
         # --- 处理动态技能调用 ---
         elif skill_manager and args.command in skill_manager.manifests:

--- a/data/skills/find-skills
+++ b/data/skills/find-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/find-skills

--- a/frontend/view/index.html
+++ b/frontend/view/index.html
@@ -402,10 +402,14 @@
                         <!-- Skills Management -->
                         <div id="settings-skills" class="settings-panel">
                             <h2 class="settings-title">技能管理</h2>
-                            <div class="settings-group-card">
+                            <div class="settings-group-card" style="padding: 16px; display: flex; flex-direction: column; gap: 12px;">
                                 <div class="install-form">
                                     <input type="text" id="skill-install-url" placeholder="技能 Git 链接 (https://...)">
                                     <button id="skill-install-btn" class="apple-btn-primary"><i class="fas fa-download"></i> 安装</button>
+                                </div>
+                                <div class="install-form">
+                                    <input type="text" id="skill-find-input" placeholder="搜索云端技能 (关键词)">
+                                    <button id="skill-find-btn" class="apple-btn-primary" style="background: var(--text-secondary);"><i class="fas fa-search"></i> 发现</button>
                                 </div>
                             </div>
                             <div class="settings-group-card no-padding" id="skills-list-container">

--- a/frontend/view/main.js
+++ b/frontend/view/main.js
@@ -850,6 +850,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const skillInstallUrl = document.getElementById('skill-install-url');
     const skillInstallBtn = document.getElementById('skill-install-btn');
+    const skillFindInput = document.getElementById('skill-find-input');
+    const skillFindBtn = document.getElementById('skill-find-btn');
     const refreshSkillsBtn = document.getElementById('refresh-skills-btn');
     const skillsListContainer = document.getElementById('skills-list-container');
 
@@ -918,6 +920,36 @@ document.addEventListener('DOMContentLoaded', () => {
             skillInstallBtn.innerHTML = '<i class="fas fa-download"></i> 安装';
             skillInstallUrl.value = '';
             loadSkillsList();
+        });
+    }
+
+    if (skillFindBtn) {
+        skillFindBtn.addEventListener('click', async () => {
+            const query = skillFindInput.value.trim();
+            if (!query) return alert('请输入搜索关键词');
+
+            skillFindBtn.disabled = true;
+            skillFindBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> 搜索中...';
+
+            skillsListContainer.innerHTML = '<p class="loading-text">正在搜索云端技能...</p>';
+
+            // We'll use the handle_command bridge to invoke npx skills find via the CLI
+            // This is a bit of a hack but ensures consistency with the terminal behavior
+            const command = `skills find ${query}`;
+            if (window.pywebview && window.pywebview.api) {
+                // We use terminal_input to run it as if in terminal,
+                // or we could add a dedicated API. Let's use handle_command for now.
+                window.pywebview.api.handle_command(`/sh butler_cli.py ${command}`);
+
+                // Show a message to user
+                skillsListContainer.innerHTML = '<p class="loading-text">结果将显示在终端视图中。</p>';
+                setTimeout(() => {
+                    switchView('terminal');
+                }, 1000);
+            }
+
+            skillFindBtn.disabled = false;
+            skillFindBtn.innerHTML = '<i class="fas fa-search"></i> 发现';
         });
     }
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,13 +1,22 @@
 {
-    "enabled_skills": [
-        "task_management",
-        "xlsx_recalc",
-        "markitdown",
-        "daily_fashion_stylist",
-        "test_skill",
-        "pdf",
-        "docx",
-        "karpathy_guidelines",
-        "skill_creator"
-    ]
+  "version": 1,
+  "enabled_skills": [
+    "task_management",
+    "xlsx_recalc",
+    "markitdown",
+    "daily_fashion_stylist",
+    "test_skill",
+    "pdf",
+    "docx",
+    "karpathy_guidelines",
+    "skill_creator"
+  ],
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/find-skills/SKILL.md",
+      "computedHash": "d31e234f0c90694a670222cdd1dafa853e051d7066beda389f1097c22dadd461"
+    }
+  }
 }

--- a/skills/find-skills
+++ b/skills/find-skills
@@ -1,0 +1,1 @@
+../.agents/skills/find-skills


### PR DESCRIPTION
This change integrates the `npx skills` tool from vercel-labs into the Butler ecosystem. It provides both a command-line interface and a frontend UI for discovering and installing agent skills. By adding the `find-skills` meta-skill, the Butler AI can now autonomously search for and suggest relevant skills to the user. Existing skills remain enabled through a hybrid `skills-lock.json` format.

---
*PR created automatically by Jules for task [3373971948112953751](https://jules.google.com/task/3373971948112953751) started by @HelloEveryboby*

## Summary by Sourcery

将基于 `npx` 的技能管理工作流集成到 Butler 的 CLI 和设置 UI 中，以支持发现和管理云托管的智能体技能。

新功能：
- 为 Butler CLI 添加一个 `skills` 子命令，用于代理 `npx skills` 操作，包括 add、remove、list 和 find。
- 引入前端技能搜索输入框和按钮，以触发由 CLI 支持的 `skills find` 操作，并将用户引导至终端视图以查看结果。
- 添加 `find-skills` 元技能（meta-skill）定义和相关连接，使智能体可以帮助用户从技能生态系统中发现并安装外部技能。

文档：
- 为新的 `find-skills` 元技能编写文档，包括何时使用它、如何搜索和评估技能，以及如何通过 Skills CLI 安装这些技能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the npx-based skills management workflow into Butler’s CLI and settings UI to support discovering and managing cloud-hosted agent skills.

New Features:
- Add a `skills` subcommand to the Butler CLI that proxies to `npx skills` operations including add, remove, list, and find.
- Introduce a frontend skills search input and button that trigger a CLI-backed `skills find` operation and direct users to the terminal view for results.
- Add the `find-skills` meta-skill definition and wiring so the agent can help users discover and install external skills from the skills ecosystem.

Documentation:
- Document the new `find-skills` meta-skill, including when to use it, how to search and evaluate skills, and how to install them via the Skills CLI.

</details>