### PR TITLE
Trae/agent 28 pf zf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,40 +1,68 @@
 # ============================================
 # AI 模型提供商配置
 # ============================================
-# 选择 AI 服务提供商: deepseek | openai | zhipu | custom
-# deepseek: DeepSeek (默认)
-# openai:  OpenAI / 兼容 OpenAI 格式的服务
-# zhipu:   智谱 AI (GLM 系列)
-# custom:  自定义 API 地址
+# 选择 AI 服务提供商:
+#   deepseek  - DeepSeek (默认)
+#   openai    - OpenAI / 兼容 OpenAI 格式
+#   zhipu     - 智谱 AI (GLM)
+#   anthropic - Anthropic Claude
+#   gemini    - Google Gemini
+#   dashscope - 通义千问 (DashScope)
+#   qianfan   - 百度文心一言 (千帆)
+#   custom    - 自定义 API 地址 (可自定义命名)
 AI_PROVIDER=deepseek
+
+# 自定义提供商名称 (当 AI_PROVIDER=custom 时用于区分多个自定义配置)
+# 示例: 我的Ollama / 公司内网网关 / OneAPI中转
+CUSTOM_PROVIDER_NAME=
 
 # 自定义 API 基础地址 (当 AI_PROVIDER=custom 时使用，或覆盖默认地址)
 # 示例:
-#   DeepSeek: https://api.deepseek.com/v1
-#   OpenAI:   https://api.openai.com/v1
-#   智谱:     https://open.bigmodel.cn/api/paas/v4
+#   DeepSeek:   https://api.deepseek.com/v1
+#   OpenAI:     https://api.openai.com/v1
+#   智谱:       https://open.bigmodel.cn/api/paas/v4
+#   Claude:     https://api.anthropic.com/v1
+#   Gemini:     https://generativelanguage.googleapis.com/v1beta/openai
+#   通义千问:    https://dashscope.aliyuncs.com/compatible-mode/v1
+#   文心一言:    https://qianfan.baidubce.com/v2
 #   本地 Ollama: http://localhost:11434/v1
 API_BASE_URL=
 
 # 模型名称 (留空则使用提供商默认模型)
 # DeepSeek 默认: deepseek-chat
 # OpenAI 默认:   gpt-3.5-turbo
-# 智谱默认:     glm-4-flash
+# 智谱默认:      glm-4-flash
+# Claude 默认:   claude-3-5-sonnet-20241022
+# Gemini 默认:   gemini-1.5-flash
+# 通义千问默认:  qwen-turbo
+# 文心一言默认:  ernie-4.0-8k
 MODEL_NAME=
 
 # ============================================
-# API 密钥配置
+# API 密钥配置 (仅需填写 AI_PROVIDER 对应的密钥)
 # ============================================
-# DeepSeek API Key (当 AI_PROVIDER=deepseek 时使用)
+# DeepSeek API Key
 DEEPSEEK_API_KEY=YOUR_DEEPSEEK_API_KEY_HERE
 
-# OpenAI API Key (当 AI_PROVIDER=openai 时使用)
+# OpenAI API Key
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY_HERE
 
-# 智谱 AI API Key (当 AI_PROVIDER=zhipu 时使用)
+# 智谱 AI API Key
 ZHIPU_API_KEY=YOUR_ZHIPU_API_KEY_HERE
 
-# 自定义 API Key (当 AI_PROVIDER=custom 时使用)
+# Anthropic Claude API Key
+ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY_HERE
+
+# Google Gemini API Key
+GEMINI_API_KEY=YOUR_GEMINI_API_KEY_HERE
+
+# 通义千问 (DashScope) API Key
+DASHSCOPE_API_KEY=YOUR_DASHSCOPE_API_KEY_HERE
+
+# 百度文心一言 (千帆) API Key
+QIANFAN_API_KEY=YOUR_QIANFAN_API_KEY_HERE
+
+# 自定义 API Key
 CUSTOM_API_KEY=YOUR_CUSTOM_API_KEY_HERE
 
 # ============================================

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,45 @@
-# DeepSeek API Key for NLP and Embeddings
+# ============================================
+# AI 模型提供商配置
+# ============================================
+# 选择 AI 服务提供商: deepseek | openai | zhipu | custom
+# deepseek: DeepSeek (默认)
+# openai:  OpenAI / 兼容 OpenAI 格式的服务
+# zhipu:   智谱 AI (GLM 系列)
+# custom:  自定义 API 地址
+AI_PROVIDER=deepseek
+
+# 自定义 API 基础地址 (当 AI_PROVIDER=custom 时使用，或覆盖默认地址)
+# 示例:
+#   DeepSeek: https://api.deepseek.com/v1
+#   OpenAI:   https://api.openai.com/v1
+#   智谱:     https://open.bigmodel.cn/api/paas/v4
+#   本地 Ollama: http://localhost:11434/v1
+API_BASE_URL=
+
+# 模型名称 (留空则使用提供商默认模型)
+# DeepSeek 默认: deepseek-chat
+# OpenAI 默认:   gpt-3.5-turbo
+# 智谱默认:     glm-4-flash
+MODEL_NAME=
+
+# ============================================
+# API 密钥配置
+# ============================================
+# DeepSeek API Key (当 AI_PROVIDER=deepseek 时使用)
 DEEPSEEK_API_KEY=YOUR_DEEPSEEK_API_KEY_HERE
 
+# OpenAI API Key (当 AI_PROVIDER=openai 时使用)
+OPENAI_API_KEY=YOUR_OPENAI_API_KEY_HERE
+
+# 智谱 AI API Key (当 AI_PROVIDER=zhipu 时使用)
+ZHIPU_API_KEY=YOUR_ZHIPU_API_KEY_HERE
+
+# 自定义 API Key (当 AI_PROVIDER=custom 时使用)
+CUSTOM_API_KEY=YOUR_CUSTOM_API_KEY_HERE
+
+# ============================================
+# 其他服务配置
+# ============================================
 # Baidu Cloud Speech API (Recommended for Chinese)
 BAIDU_APP_ID=YOUR_BAIDU_APP_ID_HERE
 BAIDU_API_KEY=YOUR_BAIDU_API_KEY_HERE

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -67,45 +67,151 @@ fi
 
 echo "-----------------------------------------------------"
 
-# --- Configure API Keys ---
-echo "Step 3: Configuring API keys..."
+# --- Configure AI Provider & API Keys ---
+echo "Step 3: 配置 AI 服务商 & API 密钥"
 
 # Check if .env file exists
 if [ -f ".env" ]; then
-    echo "An .env file already exists. Do you want to overwrite it? (y/n)"
+    echo "检测到已存在的 .env 文件。是否覆盖? (y/n)"
     read -r overwrite
     if [ "$overwrite" != "y" ]; then
-        echo "Skipping API key configuration."
+        echo "跳过 API 密钥配置。"
         echo "-----------------------------------------------------"
-        echo "🎉 Butler installation is complete!"
-        echo "You can start the assistant by running ./run.sh"
+        echo "🎉 Butler 安装完成！"
+        echo "启动助手: ./run.sh"
         exit 0
     fi
 fi
 
-# Prompt for API keys
-echo "Please enter your DeepSeek API Key:"
-read -s DEEPSEEK_API_KEY
+echo ""
+echo "========================================"
+echo "  ① 选择 AI 模型服务商"
+echo "========================================"
+echo "1) DeepSeek (默认推荐)"
+echo "2) OpenAI / 兼容 OpenAI 格式服务"
+echo "3) 智谱 AI (GLM 系列)"
+echo "4) 自定义 API 地址 (Ollama / 本地部署等)"
+echo ""
+read -r -p "请输入选项编号 [1-4，默认 1]: " provider_choice
 
-echo "Please enter your Baidu App ID:"
+provider_choice="${provider_choice:-1}"
+AI_PROVIDER=""
+API_BASE_URL=""
+MODEL_NAME=""
+API_KEY_ENV_NAME=""
+API_KEY_DISPLAY=""
+API_KEY_VALUE=""
+
+case "$provider_choice" in
+    1)
+        AI_PROVIDER="deepseek"
+        API_KEY_ENV_NAME="DEEPSEEK_API_KEY"
+        API_KEY_DISPLAY="DeepSeek API Key"
+        ;;
+    2)
+        AI_PROVIDER="openai"
+        API_KEY_ENV_NAME="OPENAI_API_KEY"
+        API_KEY_DISPLAY="OpenAI API Key"
+        ;;
+    3)
+        AI_PROVIDER="zhipu"
+        API_KEY_ENV_NAME="ZHIPU_API_KEY"
+        API_KEY_DISPLAY="智谱 API Key"
+        ;;
+    4)
+        AI_PROVIDER="custom"
+        API_KEY_ENV_NAME="CUSTOM_API_KEY"
+        API_KEY_DISPLAY="自定义 API Key"
+        echo ""
+        echo "请输入 API 基础地址（例如 http://localhost:11434/v1）："
+        read -r API_BASE_URL
+        echo "请输入模型名称（例如 qwen2.5:7b）："
+        read -r MODEL_NAME
+        ;;
+    *)
+        echo "无效选项，使用默认 DeepSeek。"
+        AI_PROVIDER="deepseek"
+        API_KEY_ENV_NAME="DEEPSEEK_API_KEY"
+        API_KEY_DISPLAY="DeepSeek API Key"
+        ;;
+esac
+
+# ② 输入对应的 API 密钥
+echo ""
+echo "========================================"
+echo "  ② 输入 API 密钥"
+echo "========================================"
+echo "当前选择: $AI_PROVIDER ($API_KEY_DISPLAY)"
+echo ""
+echo "请输入您的 $API_KEY_DISPLAY（内容将被隐藏）："
+read -s API_KEY_VALUE
+echo ""
+
+# 是否使用自定义地址（非 custom 模式下可选）
+if [ "$AI_PROVIDER" != "custom" ] && [ -z "$API_BASE_URL" ]; then
+    read -r -p "是否需要自定义 API 基础地址? (覆盖默认) [y/N]: " override_url
+    if [ "$override_url" = "y" ] || [ "$override_url" = "Y" ]; then
+        echo "请输入自定义 API 基础地址："
+        read -r API_BASE_URL
+    fi
+fi
+
+if [ "$AI_PROVIDER" != "custom" ] && [ -z "$MODEL_NAME" ]; then
+    read -r -p "是否需要自定义模型名称? (覆盖默认) [y/N]: " override_model
+    if [ "$override_model" = "y" ] || [ "$override_model" = "Y" ]; then
+        echo "请输入自定义模型名称："
+        read -r MODEL_NAME
+    fi
+fi
+
+# 可选：百度语音
+echo ""
+echo "========================================"
+echo "  语音服务配置 (可选，直接回车跳过)"
+echo "========================================"
+echo "请输入 Baidu App ID (回车跳过):"
 read BAIDU_APP_ID
-
-echo "Please enter your Baidu API Key:"
+echo "请输入 Baidu API Key (回车跳过):"
 read BAIDU_API_KEY
-
-echo "Please enter your Baidu Secret Key:"
+echo "请输入 Baidu Secret Key (回车跳过，输入将被隐藏):"
 read -s BAIDU_SECRET_KEY
+echo ""
+echo "请输入 Picovoice Access Key (回车跳过):"
+read PICOVOICE_ACCESS_KEY
 
 # Create .env file
-echo "Creating .env file..."
+echo "正在创建 .env 文件..."
 cat > .env << EOL
-DEEPSEEK_API_KEY="${DEEPSEEK_API_KEY}"
+# AI 模型提供商配置
+AI_PROVIDER="${AI_PROVIDER}"
+API_BASE_URL="${API_BASE_URL}"
+MODEL_NAME="${MODEL_NAME}"
+
+# AI API 密钥（根据 AI_PROVIDER 生效）
+DEEPSEEK_API_KEY="$([ "$AI_PROVIDER" = "deepseek" ] && echo "${API_KEY_VALUE}" || echo "")"
+OPENAI_API_KEY="$([ "$AI_PROVIDER" = "openai" ] && echo "${API_KEY_VALUE}" || echo "")"
+ZHIPU_API_KEY="$([ "$AI_PROVIDER" = "zhipu" ] && echo "${API_KEY_VALUE}" || echo "")"
+CUSTOM_API_KEY="$([ "$AI_PROVIDER" = "custom" ] && echo "${API_KEY_VALUE}" || echo "")"
+
+# 百度语音 API (可选)
 BAIDU_APP_ID="${BAIDU_APP_ID}"
 BAIDU_API_KEY="${BAIDU_API_KEY}"
 BAIDU_SECRET_KEY="${BAIDU_SECRET_KEY}"
+
+# Picovoice (可选)
+PICOVOICE_ACCESS_KEY="${PICOVOICE_ACCESS_KEY}"
+
+# MQTT （如适用）
+MQTT_BROKER=localhost
+MQTT_PORT=1883
+MQTT_TOPIC_PREFIX=butler/
 EOL
 
-echo "✅ .env file created successfully."
+echo "✅ .env 文件创建成功。"
+echo "  - AI_PROVIDER = ${AI_PROVIDER}"
+echo "  - 密钥保存到 = ${API_KEY_ENV_NAME}=\"您的_${API_KEY_DISPLAY}\"（已加密输入）"
+[ -n "$API_BASE_URL" ] && echo "  - API_BASE_URL = ${API_BASE_URL}"
+[ -n "$MODEL_NAME" ] && echo "  - MODEL_NAME = ${MODEL_NAME}"
 echo "-----------------------------------------------------"
 
 echo "🎉 Butler installation and configuration is complete!"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -90,14 +90,19 @@ echo "========================================"
 echo "1) DeepSeek (默认推荐)"
 echo "2) OpenAI / 兼容 OpenAI 格式服务"
 echo "3) 智谱 AI (GLM 系列)"
-echo "4) 自定义 API 地址 (Ollama / 本地部署等)"
+echo "4) Anthropic Claude"
+echo "5) Google Gemini"
+echo "6) 通义千问 (DashScope)"
+echo "7) 百度文心一言 (千帆)"
+echo "8) 自定义 API 地址 (Ollama / 本地部署等)"
 echo ""
-read -r -p "请输入选项编号 [1-4，默认 1]: " provider_choice
+read -r -p "请输入选项编号 [1-8，默认 1]: " provider_choice
 
 provider_choice="${provider_choice:-1}"
 AI_PROVIDER=""
 API_BASE_URL=""
 MODEL_NAME=""
+CUSTOM_PROVIDER_NAME=""
 API_KEY_ENV_NAME=""
 API_KEY_DISPLAY=""
 API_KEY_VALUE=""
@@ -119,10 +124,31 @@ case "$provider_choice" in
         API_KEY_DISPLAY="智谱 API Key"
         ;;
     4)
+        AI_PROVIDER="anthropic"
+        API_KEY_ENV_NAME="ANTHROPIC_API_KEY"
+        API_KEY_DISPLAY="Anthropic Claude API Key"
+        ;;
+    5)
+        AI_PROVIDER="gemini"
+        API_KEY_ENV_NAME="GEMINI_API_KEY"
+        API_KEY_DISPLAY="Google Gemini API Key"
+        ;;
+    6)
+        AI_PROVIDER="dashscope"
+        API_KEY_ENV_NAME="DASHSCOPE_API_KEY"
+        API_KEY_DISPLAY="通义千问 API Key"
+        ;;
+    7)
+        AI_PROVIDER="qianfan"
+        API_KEY_ENV_NAME="QIANFAN_API_KEY"
+        API_KEY_DISPLAY="文心一言 API Key"
+        ;;
+    8)
         AI_PROVIDER="custom"
         API_KEY_ENV_NAME="CUSTOM_API_KEY"
         API_KEY_DISPLAY="自定义 API Key"
         echo ""
+        read -r -p "请输入自定义名称（用于区分，例如 我的Ollama）: " CUSTOM_PROVIDER_NAME
         echo "请输入 API 基础地址（例如 http://localhost:11434/v1）："
         read -r API_BASE_URL
         echo "请输入模型名称（例如 qwen2.5:7b）："
@@ -184,13 +210,18 @@ echo "正在创建 .env 文件..."
 cat > .env << EOL
 # AI 模型提供商配置
 AI_PROVIDER="${AI_PROVIDER}"
+CUSTOM_PROVIDER_NAME="${CUSTOM_PROVIDER_NAME}"
 API_BASE_URL="${API_BASE_URL}"
 MODEL_NAME="${MODEL_NAME}"
 
-# AI API 密钥（根据 AI_PROVIDER 生效）
+# AI API 密钥（根据 AI_PROVIDER 生效，仅对应服务商写入）
 DEEPSEEK_API_KEY="$([ "$AI_PROVIDER" = "deepseek" ] && echo "${API_KEY_VALUE}" || echo "")"
 OPENAI_API_KEY="$([ "$AI_PROVIDER" = "openai" ] && echo "${API_KEY_VALUE}" || echo "")"
 ZHIPU_API_KEY="$([ "$AI_PROVIDER" = "zhipu" ] && echo "${API_KEY_VALUE}" || echo "")"
+ANTHROPIC_API_KEY="$([ "$AI_PROVIDER" = "anthropic" ] && echo "${API_KEY_VALUE}" || echo "")"
+GEMINI_API_KEY="$([ "$AI_PROVIDER" = "gemini" ] && echo "${API_KEY_VALUE}" || echo "")"
+DASHSCOPE_API_KEY="$([ "$AI_PROVIDER" = "dashscope" ] && echo "${API_KEY_VALUE}" || echo "")"
+QIANFAN_API_KEY="$([ "$AI_PROVIDER" = "qianfan" ] && echo "${API_KEY_VALUE}" || echo "")"
 CUSTOM_API_KEY="$([ "$AI_PROVIDER" = "custom" ] && echo "${API_KEY_VALUE}" || echo "")"
 
 # 百度语音 API (可选)
@@ -209,7 +240,8 @@ EOL
 
 echo "✅ .env 文件创建成功。"
 echo "  - AI_PROVIDER = ${AI_PROVIDER}"
-echo "  - 密钥保存到 = ${API_KEY_ENV_NAME}=\"您的_${API_KEY_DISPLAY}\"（已加密输入）"
+[ -n "$CUSTOM_PROVIDER_NAME" ] && echo "  - CUSTOM_PROVIDER_NAME = ${CUSTOM_PROVIDER_NAME}"
+echo "  - 密钥保存到 = ${API_KEY_ENV_NAME}（已隐藏输入）"
 [ -n "$API_BASE_URL" ] && echo "  - API_BASE_URL = ${API_BASE_URL}"
 [ -n "$MODEL_NAME" ] && echo "  - MODEL_NAME = ${MODEL_NAME}"
 echo "-----------------------------------------------------"

--- a/butler/__main__.py
+++ b/butler/__main__.py
@@ -12,6 +12,7 @@
   cli       功能型命令行 (crawl/email/encrypt 等子命令)
   agent     数字员工管理 (list|run)
   package   包管理 (list|install)
+  config    交互式配置 AI 服务商与密钥
   doctor    系统诊断自检
 
 向后兼容 (隐藏, 带废弃提示):
@@ -83,6 +84,8 @@ def main():
         _launch_agent(rest)
     elif mode == "package":
         _launch_package(rest)
+    elif mode == "config":
+        _launch_config(rest)
     elif mode == "doctor":
         _launch_doctor()
     else:
@@ -198,6 +201,13 @@ def _launch_doctor():
     doctor_cmd.run_doctor()
 
 
+def _launch_config(rest: list):
+    """交互式配置 AI 服务商与密钥."""
+    from butler.cli import config_cmd
+    sub = rest[0] if rest else ""
+    config_cmd.run_config(sub)
+
+
 # ────────────────────────────────────────────────────────────
 # 辅助
 # ────────────────────────────────────────────────────────────
@@ -250,6 +260,8 @@ def _print_help():
   python -m butler package list 列出已安装包
   python -m butler package install <路径>
                                 安装本地包
+  python -m butler config       交互式配置 AI 服务商与密钥
+  python -m butler config show  查看当前 AI 配置
   python -m butler doctor       系统诊断自检
 
 通用选项:

--- a/butler/cli/config_cmd.py
+++ b/butler/cli/config_cmd.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""交互式 AI 提供商配置命令 (`butler config`).
+
+在终端中以问答方式选择 AI 服务商、填写 API 地址/模型/密钥，
+并持久化写入 .env。与 GUI 向导、安装脚本共享同一套 PROVIDER_DEFAULTS。
+"""
+import os
+import getpass
+from pathlib import Path
+
+from dotenv import set_key, load_dotenv
+
+from butler.core.config_model import PROVIDER_DEFAULTS, PROVIDER_KEY_PATHS
+
+
+# 终端配色
+_CY = "\033[36m"
+_GR = "\033[32m"
+_YE = "\033[33m"
+_BD = "\033[1m"
+_NC = "\033[0m"
+
+
+def _env_path() -> Path:
+    return Path(__file__).resolve().parent.parent.parent / ".env"
+
+
+def _show_current():
+    """打印当前 .env 中的 AI 提供商配置状态。"""
+    env = _env_path()
+    if not env.exists():
+        print(f"{_YE}未检测到 .env 文件，将创建新文件。{_NC}\n")
+        return
+    load_dotenv(env, override=True)
+
+    provider = os.getenv("AI_PROVIDER", "deepseek") or "deepseek"
+    defaults = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["deepseek"])
+    label = os.getenv("CUSTOM_PROVIDER_NAME", "") or ""
+    base_url = os.getenv("API_BASE_URL", "") or defaults["base_url"]
+    model = os.getenv("MODEL_NAME", "") or defaults["model_name"]
+    key_env = defaults["key_env"]
+    key_val = os.getenv(key_env, "") or ""
+    masked = (key_val[:4] + "***" + key_val[-4:]) if len(key_val) > 10 else ("***" if key_val else "未配置")
+
+    name = f"{defaults['display_name']}" + (f"（{label}）" if label else "")
+    print(f"{_BD}─── 当前 AI 配置 ───{_NC}")
+    print(f"  提供商    : {provider}  ({name})")
+    print(f"  API 地址  : {base_url}")
+    print(f"  模型      : {model}")
+    print(f"  密钥变量  : {key_env} = {masked}")
+    print()
+
+
+def _pick_provider() -> str:
+    """交互选择提供商，返回 provider id。"""
+    print(f"{_BD}请选择 AI 模型服务商：{_NC}")
+    items = list(PROVIDER_DEFAULTS.items())
+    for idx, (pid, cfg) in enumerate(items, 1):
+        tag = "（需自定义地址）" if pid == "custom" else ""
+        print(f"  {idx}) {cfg['display_name']} {tag}")
+    while True:
+        choice = input(f"请输入编号 [1-{len(items)}，默认 1]: ").strip() or "1"
+        try:
+            idx = int(choice)
+            if 1 <= idx <= len(items):
+                return items[idx - 1][0]
+        except ValueError:
+            pass
+        print(f"{_YE}无效输入，请重试。{_NC}")
+
+
+def run_config(subaction: str = ""):
+    """运行交互式配置向导。
+
+    Args:
+        subaction: 可选子命令。`show` 仅显示当前配置。
+    """
+    env = _env_path()
+    # 确保 .env 存在
+    if not env.exists():
+        env.parent.mkdir(parents=True, exist_ok=True)
+        env.touch()
+    load_dotenv(env, override=True)
+
+    if subaction == "show":
+        _show_current()
+        return
+
+    _show_current()
+
+    # ① 选择服务商
+    provider = _pick_provider()
+    defaults = PROVIDER_DEFAULTS[provider]
+    print(f"\n{_GR}已选择: {defaults['display_name']}{_NC}\n")
+
+    # ② 自定义地址/模型/名称（custom 必填，其它可选覆盖）
+    custom_name = ""
+    if provider == "custom":
+        custom_name = input("🏷️  自定义名称（用于区分，例如 我的Ollama）: ").strip()
+        base_url = input("🌐 API 基础地址 (例如 http://localhost:11434/v1): ").strip()
+        while not base_url:
+            print(f"{_YE}API 地址不能为空。{_NC}")
+            base_url = input("🌐 API 基础地址: ").strip()
+        model_name = input("📋 模型名称 (例如 qwen2.5:7b): ").strip()
+        while not model_name:
+            print(f"{_YE}模型名称不能为空。{_NC}")
+            model_name = input("📋 模型名称: ").strip()
+    else:
+        base_url = ""
+        model_name = ""
+        override = input(f"是否覆盖默认地址/模型？(默认 {defaults['base_url']} / {defaults['model_name']}) [y/N]: ").strip().lower()
+        if override == "y":
+            base_url = input("🌐 API 基础地址 (留空用默认): ").strip()
+            model_name = input("📋 模型名称 (留空用默认): ").strip()
+
+    # ③ 输入密钥
+    key_env = defaults["key_env"]
+    existing_key = os.getenv(key_env, "") or ""
+    hint = f"（当前: {existing_key[:4]}***，直接回车保留）" if existing_key and "YOUR_" not in existing_key else ""
+    print(f"\n{_BD}🔑 请输入 {defaults['display_name']} API Key{hint}：{_NC}")
+    api_key = getpass.getpass("(输入内容将被隐藏): ").strip()
+    if not api_key and existing_key and "YOUR_" not in existing_key:
+        api_key = existing_key
+
+    # ④ 写入 .env
+    set_key(str(env), "AI_PROVIDER", provider)
+    set_key(str(env), "API_BASE_URL", base_url)
+    set_key(str(env), "MODEL_NAME", model_name)
+    set_key(str(env), "CUSTOM_PROVIDER_NAME", custom_name)
+    set_key(str(env), key_env, api_key)
+
+    # ⑤ 确认
+    print(f"\n{_GR}✅ 配置已保存到 {env}{_NC}")
+    display = custom_name or defaults["display_name"]
+    print(f"  AI_PROVIDER        = {provider}")
+    print(f"  显示名称           = {display}")
+    if base_url:
+        print(f"  API_BASE_URL       = {base_url}")
+    if model_name:
+        print(f"  MODEL_NAME         = {model_name}")
+    print(f"  {key_env} = {'***已设置***' if api_key else '(空)'}")
+    print(f"\n运行 {_CY}butler config show{_NC} 可随时查看当前配置。")

--- a/butler/core/config_manager.py
+++ b/butler/core/config_manager.py
@@ -75,19 +75,36 @@ class ConfigManager:
             if env_values:
                 # 将 .env 值转换为嵌套结构
                 for key, value in env_values.items():
-                    if key.startswith("DEEPSEEK"):
-                        if "api" not in self._config_cache:
-                            self._config_cache["api"] = {}
+                    if "api" not in self._config_cache:
+                        self._config_cache["api"] = {}
+
+                    # AI 提供商配置
+                    if key == "AI_PROVIDER":
+                        self._config_cache["api"]["provider"] = value
+                    elif key == "API_BASE_URL":
+                        self._config_cache["api"]["base_url"] = value
+                    elif key == "MODEL_NAME":
+                        self._config_cache["api"]["model_name"] = value
+
+                    # API 密钥
+                    elif key == "DEEPSEEK_API_KEY":
                         self._config_cache["api"]["deepseek_key"] = value
-                    elif key.startswith("BAIDU"):
-                        if "api" not in self._config_cache:
-                            self._config_cache["api"] = {}
-                        if key == "BAIDU_APP_ID":
-                            self._config_cache["api"]["baidu_app_id"] = value
-                        elif key == "BAIDU_API_KEY":
-                            self._config_cache["api"]["baidu_api_key"] = value
-                        elif key == "BAIDU_SECRET_KEY":
-                            self._config_cache["api"]["baidu_secret_key"] = value
+                    elif key == "OPENAI_API_KEY":
+                        self._config_cache["api"]["openai_key"] = value
+                    elif key == "ZHIPU_API_KEY":
+                        self._config_cache["api"]["zhipu_key"] = value
+                    elif key == "CUSTOM_API_KEY":
+                        self._config_cache["api"]["custom_key"] = value
+
+                    # 百度语音
+                    elif key == "BAIDU_APP_ID":
+                        self._config_cache["api"]["baidu_app_id"] = value
+                    elif key == "BAIDU_API_KEY":
+                        self._config_cache["api"]["baidu_api_key"] = value
+                    elif key == "BAIDU_SECRET_KEY":
+                        self._config_cache["api"]["baidu_secret_key"] = value
+                    elif key == "PICOVOICE_ACCESS_KEY":
+                        self._config_cache["api"]["picovoice_access_key"] = value
                 logger.info(f"已加载 .env 配置")
         except Exception as e:
             logger.error(f"加载 .env 配置失败: {e}")
@@ -142,17 +159,21 @@ class ConfigManager:
             # 持久化到文件
             if persist:
                 if key_path.startswith('api.'):
-                    # API 密钥保存到 .env
-                    env_key = key_path.split('.')[-1].upper()
-                    if key_path.startswith('api.deepseek'):
-                        env_key = 'DEEPSEEK_API_KEY'
-                    elif key_path.startswith('api.baidu_app'):
-                        env_key = 'BAIDU_APP_ID'
-                    elif key_path.startswith('api.baidu_api'):
-                        env_key = 'BAIDU_API_KEY'
-                    elif key_path.startswith('api.baidu_secret'):
-                        env_key = 'BAIDU_SECRET_KEY'
-                    
+                    # API 配置保存到 .env
+                    env_key_map = {
+                        'api.provider': 'AI_PROVIDER',
+                        'api.base_url': 'API_BASE_URL',
+                        'api.model_name': 'MODEL_NAME',
+                        'api.deepseek_key': 'DEEPSEEK_API_KEY',
+                        'api.openai_key': 'OPENAI_API_KEY',
+                        'api.zhipu_key': 'ZHIPU_API_KEY',
+                        'api.custom_key': 'CUSTOM_API_KEY',
+                        'api.baidu_app_id': 'BAIDU_APP_ID',
+                        'api.baidu_api_key': 'BAIDU_API_KEY',
+                        'api.baidu_secret_key': 'BAIDU_SECRET_KEY',
+                        'api.picovoice_access_key': 'PICOVOICE_ACCESS_KEY',
+                    }
+                    env_key = env_key_map.get(key_path, key_path.split('.')[-1].upper())
                     set_key(self.env_file, env_key, str(value))
                 else:
                     # 其他配置保存到 YAML
@@ -183,17 +204,27 @@ class ConfigManager:
         return self._config_cache.copy()
     
     def validate_required_keys(self) -> tuple[bool, list]:
-        """验证必需的 API 密钥是否已配置
+        """验证必需的 API 密钥是否已配置（根据当前 provider 检查对应的密钥）
         
         Returns:
             (是否有效, 缺失的密钥列表)
         """
         missing = []
-        deepseek_key = self.get('api.deepseek_key') or os.getenv('DEEPSEEK_API_KEY', '')
-        
-        if not deepseek_key or 'YOUR_' in deepseek_key:
-            missing.append('DEEPSEEK_API_KEY')
-        
+        provider = self.get('api.provider', 'deepseek') or 'deepseek'
+
+        # 根据 provider 获取对应的密钥
+        key_mapping = {
+            'deepseek': ('api.deepseek_key', 'DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY'),
+            'openai': ('api.openai_key', 'OPENAI_API_KEY', 'OPENAI_API_KEY'),
+            'zhipu': ('api.zhipu_key', 'ZHIPU_API_KEY', 'ZHIPU_API_KEY'),
+            'custom': ('api.custom_key', 'CUSTOM_API_KEY', 'CUSTOM_API_KEY'),
+        }
+        cfg_path, env_name, display_name = key_mapping.get(provider, key_mapping['deepseek'])
+
+        key_val = self.get(cfg_path) or os.getenv(env_name, '')
+        if not key_val or 'YOUR_' in key_val:
+            missing.append(display_name)
+
         return len(missing) == 0, missing
 
 

--- a/butler/core/config_manager.py
+++ b/butler/core/config_manager.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional
 from dotenv import load_dotenv, set_key, dotenv_values
 import threading
 from package.core_utils.log_manager import LogManager
+from butler.core.config_model import PROVIDER_KEY_PATHS
 
 logger = LogManager.get_logger(__name__)
 
@@ -85,18 +86,10 @@ class ConfigManager:
                         self._config_cache["api"]["base_url"] = value
                     elif key == "MODEL_NAME":
                         self._config_cache["api"]["model_name"] = value
+                    elif key == "CUSTOM_PROVIDER_NAME":
+                        self._config_cache["api"]["provider_label"] = value
 
-                    # API 密钥
-                    elif key == "DEEPSEEK_API_KEY":
-                        self._config_cache["api"]["deepseek_key"] = value
-                    elif key == "OPENAI_API_KEY":
-                        self._config_cache["api"]["openai_key"] = value
-                    elif key == "ZHIPU_API_KEY":
-                        self._config_cache["api"]["zhipu_key"] = value
-                    elif key == "CUSTOM_API_KEY":
-                        self._config_cache["api"]["custom_key"] = value
-
-                    # 百度语音
+                    # API 密钥（动态映射，新增提供商自动生效）
                     elif key == "BAIDU_APP_ID":
                         self._config_cache["api"]["baidu_app_id"] = value
                     elif key == "BAIDU_API_KEY":
@@ -105,6 +98,14 @@ class ConfigManager:
                         self._config_cache["api"]["baidu_secret_key"] = value
                     elif key == "PICOVOICE_ACCESS_KEY":
                         self._config_cache["api"]["picovoice_access_key"] = value
+                    else:
+                        # 遍历 PROVIDER_KEY_PATHS 匹配密钥环境变量
+                        for _prov, (cfg_path, env_name, _field) in PROVIDER_KEY_PATHS.items():
+                            if key == env_name:
+                                _parts = cfg_path.split(".", 1)
+                                if len(_parts) == 2:
+                                    self._config_cache["api"][_parts[1]] = value
+                                break
                 logger.info(f"已加载 .env 配置")
         except Exception as e:
             logger.error(f"加载 .env 配置失败: {e}")
@@ -164,15 +165,15 @@ class ConfigManager:
                         'api.provider': 'AI_PROVIDER',
                         'api.base_url': 'API_BASE_URL',
                         'api.model_name': 'MODEL_NAME',
-                        'api.deepseek_key': 'DEEPSEEK_API_KEY',
-                        'api.openai_key': 'OPENAI_API_KEY',
-                        'api.zhipu_key': 'ZHIPU_API_KEY',
-                        'api.custom_key': 'CUSTOM_API_KEY',
+                        'api.provider_label': 'CUSTOM_PROVIDER_NAME',
                         'api.baidu_app_id': 'BAIDU_APP_ID',
                         'api.baidu_api_key': 'BAIDU_API_KEY',
                         'api.baidu_secret_key': 'BAIDU_SECRET_KEY',
                         'api.picovoice_access_key': 'PICOVOICE_ACCESS_KEY',
                     }
+                    # 从 PROVIDER_KEY_PATHS 补充密钥映射
+                    for _prov, (cfg_path, env_name, _field) in PROVIDER_KEY_PATHS.items():
+                        env_key_map[cfg_path] = env_name
                     env_key = env_key_map.get(key_path, key_path.split('.')[-1].upper())
                     set_key(self.env_file, env_key, str(value))
                 else:
@@ -212,18 +213,14 @@ class ConfigManager:
         missing = []
         provider = self.get('api.provider', 'deepseek') or 'deepseek'
 
-        # 根据 provider 获取对应的密钥
-        key_mapping = {
-            'deepseek': ('api.deepseek_key', 'DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY'),
-            'openai': ('api.openai_key', 'OPENAI_API_KEY', 'OPENAI_API_KEY'),
-            'zhipu': ('api.zhipu_key', 'ZHIPU_API_KEY', 'ZHIPU_API_KEY'),
-            'custom': ('api.custom_key', 'CUSTOM_API_KEY', 'CUSTOM_API_KEY'),
-        }
-        cfg_path, env_name, display_name = key_mapping.get(provider, key_mapping['deepseek'])
+        # 根据 provider 从 PROVIDER_KEY_PATHS 获取对应的密钥路径
+        cfg_path, env_name, _field = PROVIDER_KEY_PATHS.get(
+            provider, PROVIDER_KEY_PATHS['deepseek']
+        )
 
         key_val = self.get(cfg_path) or os.getenv(env_name, '')
         if not key_val or 'YOUR_' in key_val:
-            missing.append(display_name)
+            missing.append(env_name)
 
         return len(missing) == 0, missing
 

--- a/butler/core/config_model.py
+++ b/butler/core/config_model.py
@@ -21,6 +21,7 @@ class QuotaConfig(BaseModel):
 
 
 # 预设的 AI 提供商默认配置
+# 添加新提供商只需在此追加一条，其余模块通过 key_env 动态解析。
 PROVIDER_DEFAULTS = {
     "deepseek": {
         "base_url": "https://api.deepseek.com/v1",
@@ -40,12 +41,49 @@ PROVIDER_DEFAULTS = {
         "key_env": "ZHIPU_API_KEY",
         "display_name": "智谱 AI",
     },
+    "anthropic": {
+        "base_url": "https://api.anthropic.com/v1",
+        "model_name": "claude-3-5-sonnet-20241022",
+        "key_env": "ANTHROPIC_API_KEY",
+        "display_name": "Anthropic Claude",
+    },
+    "gemini": {
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "model_name": "gemini-1.5-flash",
+        "key_env": "GEMINI_API_KEY",
+        "display_name": "Google Gemini",
+    },
+    "dashscope": {
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "model_name": "qwen-turbo",
+        "key_env": "DASHSCOPE_API_KEY",
+        "display_name": "通义千问 (DashScope)",
+    },
+    "qianfan": {
+        "base_url": "https://qianfan.baidubce.com/v2",
+        "model_name": "ernie-4.0-8k",
+        "key_env": "QIANFAN_API_KEY",
+        "display_name": "百度文心一言 (千帆)",
+    },
     "custom": {
         "base_url": "",
         "model_name": "",
         "key_env": "CUSTOM_API_KEY",
         "display_name": "自定义 API",
     },
+}
+
+# provider -> (config_manager 配置路径, 环境变量名, ApiConfig 字段名)
+# 单一数据源：被 nlu_service / config_manager / GUI 向导复用，避免多处重复维护。
+PROVIDER_KEY_PATHS = {
+    "deepseek":  ("api.deepseek_key",  "DEEPSEEK_API_KEY",   "deepseek_key"),
+    "openai":    ("api.openai_key",    "OPENAI_API_KEY",     "openai_key"),
+    "zhipu":     ("api.zhipu_key",     "ZHIPU_API_KEY",      "zhipu_key"),
+    "anthropic": ("api.anthropic_key", "ANTHROPIC_API_KEY",  "anthropic_key"),
+    "gemini":    ("api.gemini_key",    "GEMINI_API_KEY",      "gemini_key"),
+    "dashscope": ("api.dashscope_key", "DASHSCOPE_API_KEY",   "dashscope_key"),
+    "qianfan":   ("api.qianfan_key",   "QIANFAN_API_KEY",     "qianfan_key"),
+    "custom":    ("api.custom_key",    "CUSTOM_API_KEY",     "custom_key"),
 }
 
 
@@ -56,11 +94,17 @@ class ApiConfig(BaseModel):
     provider: str = Field("deepseek", alias="AI_PROVIDER")
     base_url: str | None = Field(None, alias="API_BASE_URL")
     model_name: str | None = Field(None, alias="MODEL_NAME")
+    # 自定义提供商名称（当 provider=custom 时用于区分多个自定义配置）
+    provider_label: str | None = Field(None, alias="CUSTOM_PROVIDER_NAME")
 
     # API 密钥
     deepseek_key: str | None = Field(None, alias="DEEPSEEK_API_KEY")
     openai_key: str | None = Field(None, alias="OPENAI_API_KEY")
     zhipu_key: str | None = Field(None, alias="ZHIPU_API_KEY")
+    anthropic_key: str | None = Field(None, alias="ANTHROPIC_API_KEY")
+    gemini_key: str | None = Field(None, alias="GEMINI_API_KEY")
+    dashscope_key: str | None = Field(None, alias="DASHSCOPE_API_KEY")
+    qianfan_key: str | None = Field(None, alias="QIANFAN_API_KEY")
     custom_key: str | None = Field(None, alias="CUSTOM_API_KEY")
 
     # 百度语音
@@ -84,19 +128,19 @@ class ApiConfig(BaseModel):
         defaults = PROVIDER_DEFAULTS.get(self.provider, PROVIDER_DEFAULTS["deepseek"])
         return defaults["model_name"]
 
+    def get_display_name(self) -> str:
+        """获取用于展示的提供商名称（自定义标签优先）。"""
+        if self.provider_label:
+            return self.provider_label
+        defaults = PROVIDER_DEFAULTS.get(self.provider, {})
+        return defaults.get("display_name", self.provider)
+
     def get_active_api_key(self) -> str | None:
-        """根据当前 provider 获取对应的 API 密钥。"""
-        provider = self.provider
-        if provider == "deepseek":
-            return self.deepseek_key
-        elif provider == "openai":
-            return self.openai_key
-        elif provider == "zhipu":
-            return self.zhipu_key
-        elif provider == "custom":
-            return self.custom_key
-        # 回退到 deepseek
-        return self.deepseek_key
+        """根据当前 provider 动态获取对应的 API 密钥。"""
+        paths = PROVIDER_KEY_PATHS.get(self.provider, PROVIDER_KEY_PATHS["deepseek"])
+        field_name = paths[2]  # ApiConfig 字段名
+        key = getattr(self, field_name, None)
+        return key if key else self.deepseek_key
 
     @property
     def ai_available(self) -> bool:
@@ -209,12 +253,13 @@ def load_config_from_env() -> ButlerConfig:
         config.api.base_url = base_url
     if model_name := os.getenv("MODEL_NAME"):
         config.api.model_name = model_name
+    if label := os.getenv("CUSTOM_PROVIDER_NAME"):
+        config.api.provider_label = label
 
-    # API 密钥
-    config.api.deepseek_key = os.getenv("DEEPSEEK_API_KEY")
-    config.api.openai_key = os.getenv("OPENAI_API_KEY")
-    config.api.zhipu_key = os.getenv("ZHIPU_API_KEY")
-    config.api.custom_key = os.getenv("CUSTOM_API_KEY")
+    # API 密钥（动态遍历 PROVIDER_KEY_PATHS，避免遗漏新增提供商）
+    for _prov, (_cfg_path, env_name, field_name) in PROVIDER_KEY_PATHS.items():
+        if val := os.getenv(env_name):
+            setattr(config.api, field_name, val)
 
     # Runner
     if host := os.getenv("BUTLER_RUNNER_HOST"):

--- a/butler/core/config_model.py
+++ b/butler/core/config_model.py
@@ -20,20 +20,88 @@ class QuotaConfig(BaseModel):
     consumed: float = 0.0
 
 
+# 预设的 AI 提供商默认配置
+PROVIDER_DEFAULTS = {
+    "deepseek": {
+        "base_url": "https://api.deepseek.com/v1",
+        "model_name": "deepseek-chat",
+        "key_env": "DEEPSEEK_API_KEY",
+        "display_name": "DeepSeek",
+    },
+    "openai": {
+        "base_url": "https://api.openai.com/v1",
+        "model_name": "gpt-3.5-turbo",
+        "key_env": "OPENAI_API_KEY",
+        "display_name": "OpenAI",
+    },
+    "zhipu": {
+        "base_url": "https://open.bigmodel.cn/api/paas/v4",
+        "model_name": "glm-4-flash",
+        "key_env": "ZHIPU_API_KEY",
+        "display_name": "智谱 AI",
+    },
+    "custom": {
+        "base_url": "",
+        "model_name": "",
+        "key_env": "CUSTOM_API_KEY",
+        "display_name": "自定义 API",
+    },
+}
+
+
 class ApiConfig(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
+    # AI 提供商配置
+    provider: str = Field("deepseek", alias="AI_PROVIDER")
+    base_url: str | None = Field(None, alias="API_BASE_URL")
+    model_name: str | None = Field(None, alias="MODEL_NAME")
+
+    # API 密钥
     deepseek_key: str | None = Field(None, alias="DEEPSEEK_API_KEY")
+    openai_key: str | None = Field(None, alias="OPENAI_API_KEY")
+    zhipu_key: str | None = Field(None, alias="ZHIPU_API_KEY")
+    custom_key: str | None = Field(None, alias="CUSTOM_API_KEY")
+
+    # 百度语音
     baidu_app_id: str | None = Field(None, alias="BAIDU_APP_ID")
     baidu_api_key: str | None = Field(None, alias="BAIDU_API_KEY")
     baidu_secret_key: str | None = Field(None, alias="BAIDU_SECRET_KEY")
     picovoice_access_key: str | None = Field(None, alias="PICOVOICE_ACCESS_KEY")
     quota: QuotaConfig = Field(default_factory=QuotaConfig)
 
+    def get_resolved_base_url(self) -> str:
+        """获取解析后的 API 基础地址（用户配置优先，否则用提供商默认）。"""
+        if self.base_url:
+            return self.base_url.rstrip("/")
+        defaults = PROVIDER_DEFAULTS.get(self.provider, PROVIDER_DEFAULTS["deepseek"])
+        return defaults["base_url"]
+
+    def get_resolved_model_name(self) -> str:
+        """获取解析后的模型名称（用户配置优先，否则用提供商默认）。"""
+        if self.model_name:
+            return self.model_name
+        defaults = PROVIDER_DEFAULTS.get(self.provider, PROVIDER_DEFAULTS["deepseek"])
+        return defaults["model_name"]
+
+    def get_active_api_key(self) -> str | None:
+        """根据当前 provider 获取对应的 API 密钥。"""
+        provider = self.provider
+        if provider == "deepseek":
+            return self.deepseek_key
+        elif provider == "openai":
+            return self.openai_key
+        elif provider == "zhipu":
+            return self.zhipu_key
+        elif provider == "custom":
+            return self.custom_key
+        # 回退到 deepseek
+        return self.deepseek_key
+
     @property
     def ai_available(self) -> bool:
         """检查是否有至少一个可用的 AI 密钥。"""
-        key = self.deepseek_key
+        key = self.get_active_api_key()
         return bool(key and "YOUR_" not in str(key))
 
 
@@ -134,8 +202,19 @@ def load_config_from_env() -> ButlerConfig:
     """
     config = ButlerConfig()
 
+    # AI 提供商配置
+    if provider := os.getenv("AI_PROVIDER"):
+        config.api.provider = provider
+    if base_url := os.getenv("API_BASE_URL"):
+        config.api.base_url = base_url
+    if model_name := os.getenv("MODEL_NAME"):
+        config.api.model_name = model_name
+
     # API 密钥
     config.api.deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+    config.api.openai_key = os.getenv("OPENAI_API_KEY")
+    config.api.zhipu_key = os.getenv("ZHIPU_API_KEY")
+    config.api.custom_key = os.getenv("CUSTOM_API_KEY")
 
     # Runner
     if host := os.getenv("BUTLER_RUNNER_HOST"):

--- a/butler/core/nlu_service.py
+++ b/butler/core/nlu_service.py
@@ -7,16 +7,81 @@ from package.core_utils.log_manager import LogManager
 from package.core_utils.config_loader import config_loader
 from package.core_utils.quota_manager import quota_manager
 from butler.core.habit_manager import habit_manager
+from butler.core.config_manager import config_manager
+from butler.core.config_model import PROVIDER_DEFAULTS
 
 logger = LogManager.get_logger(__name__)
 
+
+def _resolve_ai_config(provided_api_key: str = None) -> Dict[str, str]:
+    """解析 AI 配置：provider、base_url、model_name、api_key。"""
+    provider = (config_manager.get("api.provider")
+                or os.getenv("AI_PROVIDER")
+                or config_loader.get("ai.provider")
+                or "deepseek")
+
+    defaults = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["deepseek"])
+
+    # Base URL
+    base_url = (config_manager.get("api.base_url")
+                or os.getenv("API_BASE_URL")
+                or config_loader.get("api.deepseek.endpoint")
+                or defaults["base_url"])
+    base_url = base_url.rstrip("/") if base_url else ""
+
+    # Model name
+    model_name = (config_manager.get("api.model_name")
+                  or os.getenv("MODEL_NAME")
+                  or config_loader.get("api.deepseek.model")
+                  or defaults["model_name"])
+
+    # API key：用户传入的优先，否则根据 provider 取对应密钥
+    api_key = provided_api_key
+    if not api_key:
+        if provider == "deepseek":
+            api_key = (config_manager.get("api.deepseek_key")
+                       or os.getenv("DEEPSEEK_API_KEY")
+                       or config_loader.get("api.deepseek.key"))
+        elif provider == "openai":
+            api_key = (config_manager.get("api.openai_key")
+                       or os.getenv("OPENAI_API_KEY"))
+        elif provider == "zhipu":
+            api_key = (config_manager.get("api.zhipu_key")
+                       or os.getenv("ZHIPU_API_KEY"))
+        elif provider == "custom":
+            api_key = (config_manager.get("api.custom_key")
+                       or os.getenv("CUSTOM_API_KEY"))
+        else:
+            api_key = (config_manager.get("api.deepseek_key")
+                       or os.getenv("DEEPSEEK_API_KEY"))
+
+    return {
+        "provider": provider,
+        "base_url": base_url,
+        "model_name": model_name,
+        "api_key": api_key or "",
+    }
+
+
 class NLUService:
     def __init__(self, api_key: str, prompts: Dict[str, Any]):
-        # Prefer the provided api_key (from .env or direct call), or fall back to centralized config
-        self.api_key = api_key or config_loader.get("api.deepseek.key")
         self.prompts = prompts
-        # Centralized endpoint with fallback
-        self.url = config_loader.get("api.deepseek.endpoint", "https://api.deepseek.com/v1") + "/chat/completions"
+
+        # 根据 provider 动态解析配置
+        cfg = _resolve_ai_config(api_key)
+        self.provider = cfg["provider"]
+        self.api_key = cfg["api_key"]
+        self.model_name = cfg["model_name"]
+        self.base_url = cfg["base_url"]
+        self.url = f"{self.base_url}/chat/completions" if self.base_url else ""
+
+        # 显示名用于错误提示
+        self._provider_display = PROVIDER_DEFAULTS.get(
+            self.provider, PROVIDER_DEFAULTS["deepseek"]
+        )["display_name"]
+        self._key_env_name = PROVIDER_DEFAULTS.get(
+            self.provider, PROVIDER_DEFAULTS["deepseek"]
+        )["key_env"]
 
     def _get_augmented_system_prompt(self, base_prompt_key: str) -> str:
         """Augments the system prompt with the current user habit profile."""
@@ -64,7 +129,7 @@ class NLUService:
             return {"intent": "unauthorized_attempt", "entities": {"error": "Adversarial prompt injection attempt detected and blocked."}}
 
         if not self.api_key or "YOUR_" in self.api_key:
-             return {"intent": "unknown", "entities": {"error": "DeepSeek API Key missing or placeholder"}}
+             return {"intent": "unknown", "entities": {"error": f"{self._provider_display} API Key missing or placeholder"}}
 
         if not quota_manager.check_quota():
             logger.error("API 额度已用尽，提取意图停止。")
@@ -82,7 +147,7 @@ class NLUService:
         messages.append({"role": "user", "content": text})
 
         payload = {
-            "model": "deepseek-chat",
+            "model": self.model_name,
             "messages": messages,
             "max_tokens": 512,
             "temperature": 0
@@ -147,7 +212,7 @@ class NLUService:
 
         system_prompt = self._get_augmented_system_prompt("general_response")
         payload = {
-            "model": "deepseek-chat",
+            "model": self.model_name,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": text}
@@ -181,12 +246,12 @@ class NLUService:
 
         if not self.api_key or "YOUR_" in self.api_key:
             return (
-                "AI service unavailable.\n\n"
-                "Reason:\n"
-                "DEEPSEEK_API_KEY not configured.\n\n"
-                "Please set in `.env` file:\n"
-                "DEEPSEEK_API_KEY=xxxxx\n\n"
-                "【离线提示】当前未配置 API 密钥，仅支持本地指令。如需进行智能对话，请在 `.env` 或设置中完成 API 配置。"
+                f"AI service unavailable.\n\n"
+                f"Reason:\n"
+                f"{self._key_env_name} not configured.\n\n"
+                f"Please set in `.env` file:\n"
+                f"{self._key_env_name}=xxxxx\n\n"
+                f"【离线提示】当前未配置 {self._provider_display} API 密钥，仅支持本地指令。如需进行智能对话，请在 `.env` 或设置中完成 API 配置。"
             )
 
         if not quota_manager.check_quota():
@@ -234,11 +299,12 @@ class NLUService:
 
         messages.append({"role": "user", "content": user_content})
 
-        # 动态选择模型：如果有图片，则尝试使用支持多模态的模型 (如 gpt-4o 或 deepseek-vl)
-        # 这里默认尝试使用配置中的模型，或者根据有无图片自动切换
-        model = config_loader.get("api.deepseek.model", "deepseek-chat")
+        # 模型选择：优先使用已解析的 model_name；如果有图片且是 deepseek 默认模型，提示用户或降级
+        model = self.model_name
         if image_b64 and model == "deepseek-chat":
-            model = "gpt-4o" # 默认降级/切换到 GPT-4o 处理图片，如果 DeepSeek 不支持
+            # DeepSeek 默认 chat 模型不支持图片，切换到 gpt-4o 风格的提示（如果用户密钥兼容）
+            # 实际上应使用支持视觉的模型，这里保留旧逻辑但基于 provider 判断
+            model = model  # 保持用户配置，视觉能力由用户选择的模型决定
 
         payload = {
             "model": model,

--- a/butler/core/nlu_service.py
+++ b/butler/core/nlu_service.py
@@ -8,7 +8,7 @@ from package.core_utils.config_loader import config_loader
 from package.core_utils.quota_manager import quota_manager
 from butler.core.habit_manager import habit_manager
 from butler.core.config_manager import config_manager
-from butler.core.config_model import PROVIDER_DEFAULTS
+from butler.core.config_model import PROVIDER_DEFAULTS, PROVIDER_KEY_PATHS
 
 logger = LogManager.get_logger(__name__)
 
@@ -35,25 +35,17 @@ def _resolve_ai_config(provided_api_key: str = None) -> Dict[str, str]:
                   or config_loader.get("api.deepseek.model")
                   or defaults["model_name"])
 
-    # API key：用户传入的优先，否则根据 provider 取对应密钥
+    # API key：用户传入的优先，否则根据 provider 动态取对应密钥
     api_key = provided_api_key
     if not api_key:
-        if provider == "deepseek":
-            api_key = (config_manager.get("api.deepseek_key")
-                       or os.getenv("DEEPSEEK_API_KEY")
-                       or config_loader.get("api.deepseek.key"))
-        elif provider == "openai":
-            api_key = (config_manager.get("api.openai_key")
-                       or os.getenv("OPENAI_API_KEY"))
-        elif provider == "zhipu":
-            api_key = (config_manager.get("api.zhipu_key")
-                       or os.getenv("ZHIPU_API_KEY"))
-        elif provider == "custom":
-            api_key = (config_manager.get("api.custom_key")
-                       or os.getenv("CUSTOM_API_KEY"))
-        else:
-            api_key = (config_manager.get("api.deepseek_key")
-                       or os.getenv("DEEPSEEK_API_KEY"))
+        cfg_path, env_name, _field = PROVIDER_KEY_PATHS.get(
+            provider, PROVIDER_KEY_PATHS["deepseek"]
+        )
+        api_key = (config_manager.get(cfg_path)
+                   or os.getenv(env_name))
+        # deepseek 额外兼容 config_loader 旧路径
+        if not api_key and provider == "deepseek":
+            api_key = config_loader.get("api.deepseek.key")
 
     return {
         "provider": provider,

--- a/butler/gui/config_wizard_enhanced.py
+++ b/butler/gui/config_wizard_enhanced.py
@@ -7,17 +7,21 @@ import threading
 import requests
 import json
 from package.core_utils.log_manager import LogManager
-from butler.core.config_model import PROVIDER_DEFAULTS
+from butler.core.config_model import PROVIDER_DEFAULTS, PROVIDER_KEY_PATHS
 
 logger = LogManager.get_logger(__name__)
 
 
 # 提供商选项：(id, 显示名, 描述, 是否需要自定义地址)
 PROVIDER_OPTIONS = [
-    ("deepseek", "🤖 DeepSeek", "官方默认 - 稳定、性价比高", False),
-    ("openai",   "🧠 OpenAI / 兼容格式", "GPT 系列及兼容服务（如 OneAPI）", False),
-    ("zhipu",    "🇨🇳 智谱 AI (GLM)", "国产大模型，中文能力优秀", False),
-    ("custom",   "🔧 自定义 API 地址", "Ollama / 本地部署 / 其他兼容 OpenAI 格式的服务", True),
+    ("deepseek",  "🤖 DeepSeek", "官方默认 - 稳定、性价比高", False),
+    ("openai",    "🧠 OpenAI / 兼容格式", "GPT 系列及兼容服务（如 OneAPI）", False),
+    ("zhipu",     "🇨🇳 智谱 AI (GLM)", "国产大模型，中文能力优秀", False),
+    ("anthropic", "🎭 Anthropic Claude", "Claude 3.5/4 系列", False),
+    ("gemini",    "✨ Google Gemini", "Gemini 1.5/2.0 系列", False),
+    ("dashscope", "🇨🇳 通义千问 (Qwen)", "阿里 DashScope，中文优秀", False),
+    ("qianfan",   "🇨🇳 百度文心一言 (ERNIE)", "百度千帆平台", False),
+    ("custom",    "🔧 自定义 API 地址", "Ollama / 本地部署 / 其他兼容 OpenAI 格式的服务", True),
 ]
 
 
@@ -272,6 +276,9 @@ class EnhancedConfigWizard:
         # 自定义 API 地址（仅 custom 时必填，其他可选填覆盖）
         row = 0
         if pid == "custom":
+            self._add_form_field(form_card, row, "🏷️ 自定义名称（用于区分）", "CUSTOM_PROVIDER_NAME",
+                                 f"例如: 我的Ollama", required=False)
+            row += 1
             self._add_form_field(form_card, row, "🌐 API 基础地址 *", "base_url",
                                  f"例如: http://localhost:11434/v1", required=True)
             row += 1
@@ -329,18 +336,15 @@ class EnhancedConfigWizard:
         val = ""
         if key == "api_key":
             pid = self.selected_provider
-            if pid == "deepseek":
-                val = os.getenv("DEEPSEEK_API_KEY", "")
-            elif pid == "openai":
-                val = os.getenv("OPENAI_API_KEY", "")
-            elif pid == "zhipu":
-                val = os.getenv("ZHIPU_API_KEY", "")
-            elif pid == "custom":
-                val = os.getenv("CUSTOM_API_KEY", "")
+            defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+            key_env_name = defaults.get("key_env", "DEEPSEEK_API_KEY")
+            val = os.getenv(key_env_name, "")
         elif key == "base_url":
             val = os.getenv("API_BASE_URL", "")
         elif key == "model_name":
             val = os.getenv("MODEL_NAME", "")
+        elif key == "CUSTOM_PROVIDER_NAME":
+            val = os.getenv("CUSTOM_PROVIDER_NAME", "")
         else:
             val = os.getenv(key, "")
 
@@ -521,6 +525,7 @@ class EnhancedConfigWizard:
         api_key = self._get_field_value("api_key")
         base_url = self._get_field_value("base_url")
         model_name = self._get_field_value("model_name")
+        provider_label = self._get_field_value("CUSTOM_PROVIDER_NAME") if pid == "custom" else ""
 
         try:
             # 写入 provider
@@ -530,8 +535,11 @@ class EnhancedConfigWizard:
             set_key(self.env_path, "API_BASE_URL", base_url)
             set_key(self.env_path, "MODEL_NAME", model_name)
 
+            # 写入自定义提供商名称（仅 custom 时有效，对应 api.provider_label）
+            set_key(self.env_path, "CUSTOM_PROVIDER_NAME", provider_label)
+
             # 写入对应 key，同时清理其他提供商的 key（避免混淆）
-            all_key_envs = ["DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ZHIPU_API_KEY", "CUSTOM_API_KEY"]
+            all_key_envs = [paths[1] for paths in PROVIDER_KEY_PATHS.values()]
             for ke in all_key_envs:
                 if ke == key_env:
                     set_key(self.env_path, ke, api_key)

--- a/butler/gui/config_wizard_enhanced.py
+++ b/butler/gui/config_wizard_enhanced.py
@@ -7,12 +7,23 @@ import threading
 import requests
 import json
 from package.core_utils.log_manager import LogManager
+from butler.core.config_model import PROVIDER_DEFAULTS
 
 logger = LogManager.get_logger(__name__)
 
+
+# 提供商选项：(id, 显示名, 描述, 是否需要自定义地址)
+PROVIDER_OPTIONS = [
+    ("deepseek", "🤖 DeepSeek", "官方默认 - 稳定、性价比高", False),
+    ("openai",   "🧠 OpenAI / 兼容格式", "GPT 系列及兼容服务（如 OneAPI）", False),
+    ("zhipu",    "🇨🇳 智谱 AI (GLM)", "国产大模型，中文能力优秀", False),
+    ("custom",   "🔧 自定义 API 地址", "Ollama / 本地部署 / 其他兼容 OpenAI 格式的服务", True),
+]
+
+
 class EnhancedConfigWizard:
-    """增强的配置向导 - 支持验证、进度反馈、统一配置管理"""
-    
+    """增强的配置向导 V2 - 两步式：先选提供商，再填密钥"""
+
     def __init__(self, root=None):
         self.own_root = False
         if root is None:
@@ -24,276 +35,537 @@ class EnhancedConfigWizard:
             self.root.grab_set()
 
         self.root.title("Butler - 初始化配置")
-        self.root.geometry("600x700")
+        self.root.geometry("620x720")
         self.root.configure(bg='#1c1c1c')
-        
+
         self.env_path = Path(".env")
-        self.config_yaml_path = Path("config/config.yaml")
         load_dotenv(self.env_path)
 
-        # API 密钥字段配置
-        self.fields = [
-            ("DEEPSEEK_API_KEY", "🤖 DeepSeek API Key (必需 - 核心对话功能):", True),
-            ("BAIDU_APP_ID", "🎤 Baidu App ID (可选 - 语音功能):", False),
-            ("BAIDU_API_KEY", "🎤 Baidu API Key (可选 - 语音功能):", False),
-            ("BAIDU_SECRET_KEY", "🎤 Baidu Secret Key (可选 - 语音功能):", False),
-            ("PICOVOICE_ACCESS_KEY", "🎙️ Picovoice Access Key (可选 - 唤醒词):", False),
-        ]
+        # 状态
+        self.current_step = 1         # 1=选择提供商, 2=填写密钥
+        self.selected_provider = "deepseek"
         self.entries = {}
         self.validation_results = {}
         self.setup_complete = False
-        
-        self._setup_ui()
 
-    def _setup_ui(self):
-        """设置用户界面"""
-        # 样式配置
+        # 读取已有配置作为初始值
+        self.existing_provider = os.getenv("AI_PROVIDER", "deepseek") or "deepseek"
+        if self.existing_provider not in [p[0] for p in PROVIDER_OPTIONS]:
+            self.existing_provider = "deepseek"
+
+        self._setup_styles()
+        self._build_ui()
+        self._show_step(1)
+
+    # ---------- 样式 ----------
+    def _setup_styles(self):
         style = ttk.Style()
         style.theme_use('default')
-        style.configure("Header.TLabel", background='#1c1c1c', foreground='#00ff00', font=("Arial", 14, "bold"))
-        style.configure("TLabel", background='#1c1c1c', foreground='#ffffff', font=("Arial", 10))
-        style.configure("TEntry", fieldbackground='#000000', foreground='#00ff00')
-        style.configure("Info.TLabel", background='#1c1c1c', foreground='#cccccc', font=("Arial", 9))
-        
-        # 主框架
-        main_frame = tk.Frame(self.root, bg='#1c1c1c')
-        main_frame.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
-        
+        style.configure("Header.TLabel", background='#1c1c1c', foreground='#00ff00',
+                        font=("Arial", 15, "bold"))
+        style.configure("Step.TLabel", background='#1c1c1c', foreground='#88ff88',
+                        font=("Arial", 11, "bold"))
+        style.configure("Info.TLabel", background='#1c1c1c', foreground='#cccccc',
+                        font=("Arial", 9))
+        style.configure("Card.TFrame", background='#252525')
+
+    # ---------- 主 UI ----------
+    def _build_ui(self):
+        self.main_frame = tk.Frame(self.root, bg='#1c1c1c')
+        self.main_frame.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
+
         # 标题
-        header = ttk.Label(main_frame, text="欢迎使用 Butler!", style="Header.TLabel")
-        header.pack(pady=(0, 10))
-        
-        # 说明文本
-        info = ttk.Label(main_frame, 
-                        text="请配置以下 API 密钥以开启全部功能。\n必需项为 DeepSeek，其他为可选。\n系统会自动验证密钥有效性。",
-                        style="Info.TLabel", justify=tk.LEFT)
-        info.pack(pady=(0, 20))
-        
-        # 表单框架（使用 Canvas 支持滚动）
-        canvas = tk.Canvas(main_frame, bg='#1c1c1c', highlightthickness=0)
-        scrollbar = ttk.Scrollbar(main_frame, orient="vertical", command=canvas.yview)
-        scrollable_frame = tk.Frame(canvas, bg='#1c1c1c')
-        
-        scrollable_frame.bind(
-            "<Configure>",
-            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
-        )
-        
-        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        ttk.Label(self.main_frame, text="🤖 Butler 配置向导", style="Header.TLabel").pack(pady=(0, 5))
+        ttk.Label(self.main_frame,
+                  text="两步完成 AI 能力配置：选择服务商 → 填入密钥",
+                  style="Info.TLabel").pack(pady=(0, 15))
+
+        # 步骤指示器
+        self.step_indicator = tk.Frame(self.main_frame, bg='#1c1c1c')
+        self.step_indicator.pack(fill=tk.X, pady=(0, 15))
+        self._build_step_indicator()
+
+        # 动态内容容器
+        self.content_frame = tk.Frame(self.main_frame, bg='#1c1c1c')
+        self.content_frame.pack(fill=tk.BOTH, expand=True)
+
+        # 底部按钮
+        self.btn_frame = tk.Frame(self.main_frame, bg='#1c1c1c')
+        self.btn_frame.pack(pady=(15, 0), fill=tk.X)
+
+    def _build_step_indicator(self):
+        for w in self.step_indicator.winfo_children():
+            w.destroy()
+
+        steps = [
+            (1, "选择模型服务商"),
+            (2, "输入 API 密钥"),
+        ]
+        for i, (num, label) in enumerate(steps):
+            active = (num == self.current_step)
+            done = (num < self.current_step)
+
+            bg = "#00aa00" if done or active else "#333333"
+            fg = "#000000" if done or active else "#888888"
+
+            # 圆圈
+            circle = tk.Label(self.step_indicator, text=str(num),
+                              bg=bg, fg=fg, width=3, height=1,
+                              font=("Arial", 10, "bold"))
+            circle.grid(row=0, column=i*2, padx=(0, 5))
+
+            # 文字
+            tk.Label(self.step_indicator, text=label,
+                     bg='#1c1c1c',
+                     fg="#00ff00" if active else ("#00aa00" if done else "#666666"),
+                     font=("Arial", 10, "bold" if active else "normal")).grid(
+                row=0, column=i*2 + 1, padx=(0, 20 if i < len(steps)-1 else 0), sticky='w')
+
+            # 连接线
+            if i < len(steps) - 1:
+                tk.Frame(self.step_indicator, bg="#333333", width=40, height=2).grid(
+                    row=0, column=i*2 + 2, pady=(0, 0))
+
+    # ---------- 步骤 1: 选择提供商 ----------
+    def _show_step(self, step):
+        self.current_step = step
+        self._build_step_indicator()
+
+        for w in self.content_frame.winfo_children():
+            w.destroy()
+        for w in self.btn_frame.winfo_children():
+            w.destroy()
+
+        if step == 1:
+            self._build_step1()
+            self._build_buttons_step1()
+        elif step == 2:
+            self._build_step2()
+            self._build_buttons_step2()
+
+    def _build_step1(self):
+        ttk.Label(self.content_frame, text="步骤 1 / 2 ：选择 AI 模型服务商",
+                  style="Step.TLabel").pack(anchor='w', pady=(0, 10))
+
+        self.provider_var = tk.StringVar(value=self.existing_provider)
+
+        # 选项卡片
+        card_frame = tk.Frame(self.content_frame, bg='#1c1c1c')
+        card_frame.pack(fill=tk.BOTH, expand=True)
+
+        canvas = tk.Canvas(card_frame, bg='#1c1c1c', highlightthickness=0)
+        scrollbar = ttk.Scrollbar(card_frame, orient="vertical", command=canvas.yview)
+        scrollable = tk.Frame(canvas, bg='#1c1c1c')
+
+        scrollable.bind("<Configure>",
+                        lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+        canvas.create_window((0, 0), window=scrollable, anchor="nw")
         canvas.configure(yscrollcommand=scrollbar.set)
-        
-        # 添加表单字段
-        for env_key, label_text, required in self.fields:
-            row = tk.Frame(scrollable_frame, bg='#1c1c1c')
-            row.pack(fill=tk.X, pady=8)
-            
-            # 标签
-            required_mark = " *" if required else ""
-            lbl = tk.Label(row, text=label_text + required_mark, bg='#1c1c1c', fg='#ffffff', 
-                          width=30, anchor='w', font=("Arial", 9))
-            lbl.pack(side=tk.LEFT)
-            
-            # 输入框
-            val = os.getenv(env_key, "")
-            if "YOUR_" in val:
-                val = ""
-            
-            ent = tk.Entry(row, bg='#000000', fg='#00ff00', insertbackground='#00ff00', 
-                          borderwidth=1, font=("Arial", 9))
-            ent.insert(0, val)
-            ent.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(10, 0))
-            
-            # 状态指示器
-            status_label = tk.Label(row, text="○", bg='#1c1c1c', fg='#888888', 
-                                   font=("Arial", 12), width=2)
-            status_label.pack(side=tk.LEFT, padx=(5, 0))
-            
-            self.entries[env_key] = {
-                'entry': ent,
-                'status_label': status_label,
-                'required': required,
-                'env_key': env_key
-            }
-        
+
+        self.provider_cards = {}
+        for idx, (pid, name, desc, is_custom) in enumerate(PROVIDER_OPTIONS):
+            card = self._make_provider_card(scrollable, pid, name, desc, is_custom)
+            card.pack(fill=tk.X, pady=(0, 8), padx=2)
+            self.provider_cards[pid] = card
+
         canvas.pack(side="left", fill="both", expand=True)
         scrollbar.pack(side="right", fill="y")
-        
-        # 按钮框架
-        btn_frame = tk.Frame(main_frame, bg='#1c1c1c')
-        btn_frame.pack(pady=20, fill=tk.X)
-        
-        # 测试按钮
-        test_btn = tk.Button(btn_frame, text="🧪 测试密钥", command=self.test_api_keys,
-                            bg='#444444', fg='#ffffff', padx=15, pady=8, borderwidth=0,
-                            font=("Arial", 10), cursor="hand2")
-        test_btn.pack(side=tk.LEFT, padx=5)
-        
-        # 保存并启动按钮
-        save_btn = tk.Button(btn_frame, text="✅ 保存并启动", command=self.save_and_close,
-                            bg='#00aa00', fg='#000000', padx=20, pady=8, borderwidth=0,
-                            font=("Arial", 10, "bold"), cursor="hand2")
-        save_btn.pack(side=tk.LEFT, padx=5)
-        
-        # 跳过按钮
-        skip_btn = tk.Button(btn_frame, text="⏭️ 稍后配置", command=self.skip_setup,
-                            bg='#333333', fg='#ffffff', padx=15, pady=8, borderwidth=0,
-                            font=("Arial", 10), cursor="hand2")
-        skip_btn.pack(side=tk.LEFT, padx=5)
-        
-        # 状态消息框
-        self.status_text = scrolledtext.ScrolledText(main_frame, height=5, width=70,
+
+        # 选中默认项
+        self._on_provider_select(self.existing_provider)
+
+    def _make_provider_card(self, parent, pid, name, desc, is_custom):
+        defaults = PROVIDER_DEFAULTS.get(pid, {})
+        default_url = defaults.get("base_url", "")
+        default_model = defaults.get("model_name", "")
+
+        # 卡片容器
+        card = tk.Frame(parent, bg='#252525', highlightthickness=1,
+                        highlightbackground='#333333')
+        inner = tk.Frame(card, bg='#252525', padx=12, pady=10)
+        inner.pack(fill=tk.X)
+
+        # 单选按钮 + 名称
+        top_row = tk.Frame(inner, bg='#252525')
+        top_row.pack(fill=tk.X)
+
+        rb = tk.Radiobutton(top_row, variable=self.provider_var, value=pid,
+                            text=name, bg='#252525', fg='#ffffff',
+                            selectcolor='#252525', activebackground='#252525',
+                            activeforeground='#00ff00', font=("Arial", 11, "bold"),
+                            command=lambda p=pid: self._on_provider_select(p),
+                            cursor="hand2")
+        rb.pack(side=tk.LEFT)
+
+        # 描述
+        tk.Label(inner, text=desc, bg='#252525', fg='#aaaaaa',
+                 font=("Arial", 8), wraplength=500, justify=tk.LEFT).pack(
+            anchor='w', pady=(4, 0))
+
+        # 默认信息
+        info_txt = ""
+        if not is_custom:
+            info_txt = f"默认地址: {default_url}    默认模型: {default_model}"
+        else:
+            info_txt = "下一步可手动填写 API 基础地址和模型名称（兼容 OpenAI 格式，如 http://localhost:11434/v1）"
+
+        tk.Label(inner, text=info_txt, bg='#252525', fg='#66aa66',
+                 font=("Arial", 8), wraplength=500, justify=tk.LEFT).pack(
+            anchor='w', pady=(4, 0))
+
+        # 整个卡片点击也能选中
+        def _on_click(e=None, p=pid):
+            self.provider_var.set(p)
+            self._on_provider_select(p)
+
+        for w in (card, inner, top_row):
+            w.bind("<Button-1>", _on_click)
+
+        card._radio = rb
+        card._pid = pid
+        return card
+
+    def _on_provider_select(self, pid):
+        self.selected_provider = pid
+        # 更新卡片高亮
+        for cpid, card in self.provider_cards.items():
+            selected = (cpid == pid)
+            color = "#00aa00" if selected else "#333333"
+            card.configure(highlightbackground=color, highlightthickness=2 if selected else 1)
+
+    def _build_buttons_step1(self):
+        tk.Button(self.btn_frame, text="下一步 →", command=self._goto_step2,
+                  bg='#00aa00', fg='#000000', padx=25, pady=8, borderwidth=0,
+                  font=("Arial", 10, "bold"), cursor="hand2").pack(side=tk.RIGHT, padx=5)
+
+        tk.Button(self.btn_frame, text="⏭️ 稍后配置", command=self.skip_setup,
+                  bg='#333333', fg='#ffffff', padx=15, pady=8, borderwidth=0,
+                  font=("Arial", 10), cursor="hand2").pack(side=tk.RIGHT, padx=5)
+
+    # ---------- 步骤 2: 填写密钥 ----------
+    def _goto_step2(self):
+        self._show_step(2)
+
+    def _build_step2(self):
+        pid = self.selected_provider
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+        display_name = defaults["display_name"]
+        key_env = defaults["key_env"]
+        default_url = defaults["base_url"]
+        default_model = defaults["model_name"]
+
+        ttk.Label(self.content_frame,
+                  text=f"步骤 2 / 2 ：配置 {display_name} API",
+                  style="Step.TLabel").pack(anchor='w', pady=(0, 10))
+
+        info = f"当前选择：{display_name}"
+        ttk.Label(self.content_frame, text=info,
+                  background='#1c1c1c', foreground='#00ff00',
+                  font=("Arial", 10, "bold")).pack(anchor='w')
+
+        # 表单卡片
+        form_card = tk.Frame(self.content_frame, bg='#252525', padx=15, pady=15)
+        form_card.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
+
+        self.entries = {}
+
+        # 自定义 API 地址（仅 custom 时必填，其他可选填覆盖）
+        row = 0
+        if pid == "custom":
+            self._add_form_field(form_card, row, "🌐 API 基础地址 *", "base_url",
+                                 f"例如: http://localhost:11434/v1", required=True)
+            row += 1
+            self._add_form_field(form_card, row, "📋 模型名称 *", "model_name",
+                                 f"例如: qwen2.5:7b 或 llama3.1", required=True)
+            row += 1
+        else:
+            # 其他提供商允许覆盖
+            self._add_form_field(form_card, row, "🌐 API 基础地址 (可选)", "base_url",
+                                 f"留空使用默认：{default_url}", required=False)
+            row += 1
+            self._add_form_field(form_card, row, "📋 模型名称 (可选)", "model_name",
+                                 f"留空使用默认：{default_model}", required=False)
+            row += 1
+
+        # API 密钥
+        self._add_form_field(form_card, row, f"🔑 {display_name} API Key *",
+                             "api_key", f"将保存到环境变量 {key_env}", required=True)
+        row += 1
+
+        # 百度语音（可选，折叠在后面）
+        ttk.Label(form_card, text="\n🎤 语音服务（可选，留空跳过）",
+                  background='#252525', foreground='#88ff88',
+                  font=("Arial", 10, "bold")).pack(anchor='w', pady=(15, 5))
+
+        self._add_form_field(form_card, row, "Baidu App ID", "BAIDU_APP_ID", "", False)
+        row += 1
+        self._add_form_field(form_card, row, "Baidu API Key", "BAIDU_API_KEY", "", False)
+        row += 1
+        self._add_form_field(form_card, row, "Baidu Secret Key", "BAIDU_SECRET_KEY", "", False)
+        row += 1
+        self._add_form_field(form_card, row, "Picovoice Access Key", "PICOVOICE_ACCESS_KEY", "", False)
+        row += 1
+
+        # 底部状态
+        self.status_text = scrolledtext.ScrolledText(self.content_frame, height=5,
                                                      bg='#000000', fg='#00ff00',
-                                                     font=("Courier", 8),
-                                                     borderwidth=1)
-        self.status_text.pack(pady=(10, 0), fill=tk.BOTH, expand=True)
+                                                     font=("Courier", 8), borderwidth=1)
+        self.status_text.pack(fill=tk.BOTH, pady=(10, 0))
+        self.status_text.insert(tk.END, "💡 提示：填写完毕后可点击「测试密钥」验证有效性\n")
+
+    def _add_form_field(self, parent, row_idx, label, key, placeholder, required=False):
+        row = tk.Frame(parent, bg='#252525')
+        row.pack(fill=tk.X, pady=6)
+
+        required_mark = " *" if required else ""
+        lbl = tk.Label(row, text=label + required_mark, bg='#252525', fg='#ffffff',
+                       width=24, anchor='w', font=("Arial", 9))
+        lbl.pack(side=tk.LEFT)
+
+        ent = tk.Entry(row, bg='#000000', fg='#00ff00', insertbackground='#00ff00',
+                       borderwidth=1, font=("Arial", 9))
+
+        # 预填已有值
+        val = ""
+        if key == "api_key":
+            pid = self.selected_provider
+            if pid == "deepseek":
+                val = os.getenv("DEEPSEEK_API_KEY", "")
+            elif pid == "openai":
+                val = os.getenv("OPENAI_API_KEY", "")
+            elif pid == "zhipu":
+                val = os.getenv("ZHIPU_API_KEY", "")
+            elif pid == "custom":
+                val = os.getenv("CUSTOM_API_KEY", "")
+        elif key == "base_url":
+            val = os.getenv("API_BASE_URL", "")
+        elif key == "model_name":
+            val = os.getenv("MODEL_NAME", "")
+        else:
+            val = os.getenv(key, "")
+
+        if "YOUR_" in val:
+            val = ""
+        if val:
+            ent.insert(0, val)
+
+        ent.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(10, 0))
+
+        if placeholder and not val:
+            # 用 insert 占位符的方式
+            ent.config(fg='#555555')
+            ent.insert(0, placeholder)
+            def _on_focus_in(e, ph=placeholder):
+                if ent.get() == ph:
+                    ent.delete(0, tk.END)
+                    ent.config(fg='#00ff00')
+            def _on_focus_out(e, ph=placeholder):
+                if ent.get() == "":
+                    ent.insert(0, ph)
+                    ent.config(fg='#555555')
+            ent.bind("<FocusIn>", _on_focus_in)
+            ent.bind("<FocusOut>", _on_focus_out)
+
+        self.entries[key] = {'entry': ent, 'required': required, 'placeholder': placeholder}
+
+    def _build_buttons_step2(self):
+        # 测试
+        tk.Button(self.btn_frame, text="🧪 测试密钥", command=self.test_api_keys,
+                  bg='#444444', fg='#ffffff', padx=15, pady=8, borderwidth=0,
+                  font=("Arial", 10), cursor="hand2").pack(side=tk.LEFT, padx=5)
+        # 上一步
+        tk.Button(self.btn_frame, text="← 上一步", command=lambda: self._show_step(1),
+                  bg='#333333', fg='#ffffff', padx=15, pady=8, borderwidth=0,
+                  font=("Arial", 10), cursor="hand2").pack(side=tk.RIGHT, padx=5)
+        # 保存
+        tk.Button(self.btn_frame, text="✅ 保存并启动", command=self.save_and_close,
+                  bg='#00aa00', fg='#000000', padx=25, pady=8, borderwidth=0,
+                  font=("Arial", 10, "bold"), cursor="hand2").pack(side=tk.RIGHT, padx=5)
+
+    # ---------- 测试 & 验证 ----------
+    def _get_field_value(self, key):
+        info = self.entries.get(key)
+        if not info:
+            return ""
+        val = info['entry'].get().strip()
+        if val == info.get('placeholder', None):
+            return ""
+        return val
+
+    def _resolve_request_config(self):
+        """根据当前选择解析出调用 API 所需的 url / key / model。"""
+        pid = self.selected_provider
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+
+        base_url = self._get_field_value("base_url") or defaults["base_url"]
+        model = self._get_field_value("model_name") or defaults["model_name"]
+        api_key = self._get_field_value("api_key")
+
+        base_url = base_url.rstrip("/") if base_url else ""
+        url = f"{base_url}/chat/completions" if base_url else ""
+
+        return url, api_key, model
 
     def test_api_keys(self):
-        """测试 API 密钥有效性"""
         self.status_text.delete(1.0, tk.END)
-        self.status_text.insert(tk.END, "🔍 正在验证 API 密钥...\n")
+        self.status_text.insert(tk.END, "🔍 正在验证 API 配置...\n")
         self.root.update()
-        
-        # 在后台线程中执行测试
         threading.Thread(target=self._test_keys_background, daemon=True).start()
 
     def _test_keys_background(self):
-        """后台验证 API 密钥"""
-        deepseek_key = self.entries["DEEPSEEK_API_KEY"]['entry'].get().strip()
-        
-        # 清空之前的验证结果
-        self.validation_results.clear()
-        
-        # 验证 DeepSeek
-        if deepseek_key:
-            self.status_text.insert(tk.END, "\n📍 测试 DeepSeek API...")
-            self.root.update()
-            
-            result = self._validate_deepseek_key(deepseek_key)
-            if result['valid']:
-                self.status_text.insert(tk.END, " ✅\n")
-                self.validation_results['DEEPSEEK_API_KEY'] = True
-                self._update_status_indicator('DEEPSEEK_API_KEY', True)
-            else:
-                self.status_text.insert(tk.END, f" ❌\n   错误: {result['error']}\n")
-                self.validation_results['DEEPSEEK_API_KEY'] = False
-                self._update_status_indicator('DEEPSEEK_API_KEY', False)
-        else:
-            self.status_text.insert(tk.END, "\n⚠️ DeepSeek API Key 未填写\n")
-            self._update_status_indicator('DEEPSEEK_API_KEY', False)
-        
-        # 验证 Baidu（如果填写）
-        baidu_app_id = self.entries["BAIDU_APP_ID"]['entry'].get().strip()
-        if baidu_app_id:
-            self.status_text.insert(tk.END, "\n📍 测试 Baidu API...")
-            self.root.update()
-            
-            result = self._validate_baidu_key(baidu_app_id)
-            if result['valid']:
-                self.status_text.insert(tk.END, " ✅\n")
-                self.validation_results['BAIDU_API_KEY'] = True
-                self._update_status_indicator('BAIDU_APP_ID', True)
-            else:
-                self.status_text.insert(tk.END, f" ❌\n   错误: {result['error']}\n")
-                self.validation_results['BAIDU_API_KEY'] = False
-                self._update_status_indicator('BAIDU_APP_ID', False)
-        
-        # 总结
-        self.status_text.insert(tk.END, "\n" + "="*50)
-        if self.validation_results.get('DEEPSEEK_API_KEY', False):
-            self.status_text.insert(tk.END, "\n✅ 验证完成！所有必需的密钥都已有效。\n")
-        else:
-            self.status_text.insert(tk.END, "\n⚠️ 请检查必需的 API 密钥。\n")
-        
+        pid = self.selected_provider
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+        display_name = defaults["display_name"]
+
+        url, api_key, model = self._resolve_request_config()
+
+        self.status_text.insert(tk.END, f"\n📍 服务商: {display_name}")
+        self.status_text.insert(tk.END, f"\n📍 地址: {url or '(空)'}")
+        self.status_text.insert(tk.END, f"\n📍 模型: {model or '(空)'}")
+        self.status_text.insert(tk.END, f"\n📍 密钥: {'已填写' if api_key and 'YOUR_' not in api_key else '未填写'}")
         self.root.update()
 
-    def _validate_deepseek_key(self, api_key: str) -> dict:
-        """验证 DeepSeek API 密钥"""
+        if not api_key or "YOUR_" in api_key:
+            self.status_text.insert(tk.END, "\n⚠️ API Key 未填写或为占位符。\n")
+            self.root.update()
+            return
+
+        if not url:
+            self.status_text.insert(tk.END, "\n❌ API 基础地址为空（自定义模式必填）\n")
+            self.root.update()
+            return
+
+        if not model:
+            self.status_text.insert(tk.END, "\n⚠️ 模型名称为空，可能会导致请求失败。\n")
+            self.root.update()
+
+        self.status_text.insert(tk.END, f"\n\n🧪 发送测试请求到 {url} ...")
+        self.root.update()
+
+        result = self._validate_any_provider(url, api_key, model)
+        if result['valid']:
+            self.status_text.insert(tk.END, " ✅\n🎉 验证成功！配置可以正常使用。\n")
+            self.validation_results['api_key'] = True
+        else:
+            self.status_text.insert(tk.END, f" ❌\n错误: {result.get('error', '未知错误')}\n")
+            self.validation_results['api_key'] = False
+        self.root.update()
+
+    def _validate_any_provider(self, url, api_key, model) -> dict:
+        """通用 OpenAI 格式 API 验证。"""
         try:
             response = requests.post(
-                "https://api.deepseek.com/chat/completions",
+                url,
                 headers={
                     "Authorization": f"Bearer {api_key}",
                     "Content-Type": "application/json"
                 },
                 json={
-                    "model": "deepseek-chat",
-                    "messages": [{"role": "user", "content": "test"}],
-                    "max_tokens": 1
+                    "model": model,
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                    "temperature": 0,
                 },
-                timeout=5
+                timeout=10,
             )
-            
             if response.status_code == 200:
-                return {'valid': True}
+                data = response.json()
+                if "choices" in data:
+                    return {'valid': True}
+                return {'valid': False, 'error': f"响应格式异常: {str(data)[:100]}"}
             elif response.status_code == 401:
-                return {'valid': False, 'error': '密钥无效或已过期'}
+                return {'valid': False, 'error': '认证失败 (401)：API Key 无效或已过期'}
+            elif response.status_code == 403:
+                return {'valid': False, 'error': '权限不足 (403)：请检查账号权限'}
+            elif response.status_code == 404:
+                return {'valid': False, 'error': f'地址不存在 (404)：请检查 {url}'}
             elif response.status_code == 429:
-                return {'valid': False, 'error': '请求过于频繁'}
+                return {'valid': False, 'error': '请求过于频繁 (429)：请稍后重试'}
             else:
-                return {'valid': False, 'error': f'HTTP {response.status_code}'}
+                try:
+                    msg = response.json()
+                except Exception:
+                    msg = response.text
+                return {'valid': False, 'error': f'HTTP {response.status_code}: {str(msg)[:150]}'}
         except requests.exceptions.Timeout:
-            return {'valid': False, 'error': '连接超时'}
+            return {'valid': False, 'error': '连接超时，请检查网络或地址是否正确'}
         except requests.exceptions.ConnectionError:
-            return {'valid': False, 'error': '网络连接失败'}
+            return {'valid': False, 'error': '网络连接失败，请检查地址、端口或网络'}
         except Exception as e:
             return {'valid': False, 'error': str(e)}
 
-    def _validate_baidu_key(self, app_id: str) -> dict:
-        """验证 Baidu API 密钥（简单检查）"""
-        try:
-            if len(app_id) >= 5:  # Baidu App ID 通常足够长
-                return {'valid': True}
-            else:
-                return {'valid': False, 'error': 'App ID 格式无效'}
-        except Exception as e:
-            return {'valid': False, 'error': str(e)}
-
-    def _update_status_indicator(self, env_key: str, is_valid: bool):
-        """更新状态指示器"""
-        if env_key in self.entries:
-            status_label = self.entries[env_key]['status_label']
-            if is_valid:
-                status_label.config(text="✅", fg='#00aa00')
-            else:
-                status_label.config(text="❌", fg='#ff4444')
-
+    # ---------- 保存 ----------
     def save_and_close(self):
-        """保存配置并关闭向导"""
-        # 验证必需字段
-        deepseek_key = self.entries["DEEPSEEK_API_KEY"]['entry'].get().strip()
-        
-        if not deepseek_key:
-            messagebox.showerror("错误", "DeepSeek API Key 是必需的！")
-            return
-        
-        if "YOUR_" in deepseek_key:
-            messagebox.showerror("错误", "请填写真实的 API Key！")
-            return
-        
-        # 保存所有密钥到 .env
+        pid = self.selected_provider
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+        key_env = defaults["key_env"]
+        display_name = defaults["display_name"]
+
+        # 必填校验
+        required_fields = ['api_key']
+        if pid == "custom":
+            required_fields += ['base_url', 'model_name']
+
+        for f in required_fields:
+            v = self._get_field_value(f)
+            if not v or "YOUR_" in v:
+                label_map = {
+                    'api_key': f'{display_name} API Key',
+                    'base_url': 'API 基础地址',
+                    'model_name': '模型名称',
+                }
+                messagebox.showerror("缺少必填项",
+                                     f"请填写：{label_map.get(f, f)}")
+                return
+
+        api_key = self._get_field_value("api_key")
+        base_url = self._get_field_value("base_url")
+        model_name = self._get_field_value("model_name")
+
         try:
-            for env_key, _, _ in self.fields:
-                value = self.entries[env_key]['entry'].get().strip()
-                if value and "YOUR_" not in value:
-                    set_key(self.env_path, env_key, value)
-                    logger.info(f"已保存 {env_key}")
-            
-            # 保存配置标记
+            # 写入 provider
+            set_key(self.env_path, "AI_PROVIDER", pid)
+
+            # 写入 base_url / model_name（空值也写入以覆盖旧值）
+            set_key(self.env_path, "API_BASE_URL", base_url)
+            set_key(self.env_path, "MODEL_NAME", model_name)
+
+            # 写入对应 key，同时清理其他提供商的 key（避免混淆）
+            all_key_envs = ["DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ZHIPU_API_KEY", "CUSTOM_API_KEY"]
+            for ke in all_key_envs:
+                if ke == key_env:
+                    set_key(self.env_path, ke, api_key)
+                elif os.getenv(ke):
+                    # 保留旧值但注释掉（更安全）
+                    # 这里简单地不改动其他 key
+                    pass
+
+            # 百度 & Picovoice 可选
+            optional_keys = ["BAIDU_APP_ID", "BAIDU_API_KEY", "BAIDU_SECRET_KEY", "PICOVOICE_ACCESS_KEY"]
+            for ke in optional_keys:
+                v = self._get_field_value(ke)
+                if v and "YOUR_" not in v:
+                    set_key(self.env_path, ke, v)
+
+            logger.info(f"配置已保存：AI_PROVIDER={pid}, {key_env}=***")
             self.setup_complete = True
-            messagebox.showinfo("成功", "配置已保存！Butler 将在 3 秒后启动...")
+            messagebox.showinfo("成功",
+                                f"✅ 配置已保存到 .env 文件！\n\n"
+                                f"提供商: {display_name}\n"
+                                f"密钥已保存至: {key_env}\n\n"
+                                f"Butler 将在 3 秒后启动...")
             self.root.after(3000, self._close_wizard)
         except Exception as e:
             messagebox.showerror("保存失败", f"无法保存配置：{str(e)}")
             logger.error(f"Failed to save config: {e}")
 
+    # ---------- 跳过 / 关闭 ----------
     def skip_setup(self):
-        """跳过配置设置"""
         if messagebox.askyesno("确认", "确定要跳过配置吗？某些功能将无法使用。"):
             self.setup_complete = True
             self._close_wizard()
 
     def _close_wizard(self):
-        """关闭向导"""
         if self.own_root:
             self.root.quit()
         else:
@@ -301,16 +573,17 @@ class EnhancedConfigWizard:
 
 
 def show_config_wizard_if_needed():
-    """检查是否需要显示配置向导（增强版）"""
-    from package.core_utils.config_loader import config_loader
-    
-    # 检查是否已配置了必需的 API 密钥
-    deepseek_key = config_loader.get("api.deepseek_key") or os.getenv("DEEPSEEK_API_KEY", "")
-    
-    if not deepseek_key or "YOUR_" in deepseek_key:
-        logger.info("检测到缺少 API 密钥，显示配置向导")
-        wizard = EnhancedConfigWizard()
-        wizard.root.mainloop()
-        return wizard.setup_complete
-    
-    return False
+    """当缺少必需配置时弹出向导。"""
+    from butler.core.config_manager import config_manager
+    is_valid, missing = config_manager.validate_required_keys()
+    if is_valid:
+        return False
+    logger.info(f"检测到缺失配置: {missing}，弹出配置向导")
+    wizard = EnhancedConfigWizard()
+    wizard.root.mainloop()
+    return True
+
+
+if __name__ == "__main__":
+    w = EnhancedConfigWizard()
+    w.root.mainloop()

--- a/butler/gui/config_wizard_enhanced_v2.py
+++ b/butler/gui/config_wizard_enhanced_v2.py
@@ -7,12 +7,31 @@ from typing import Dict, Any, List
 from butler.core.api_validator import APIValidator
 from butler.core.config_backup_manager import ConfigBackupManager
 from butler.core.config_manager import config_manager
+from butler.core.config_model import PROVIDER_DEFAULTS
 from package.core_utils.log_manager import LogManager
 
 logger = LogManager.get_logger(__name__)
 
+
+# 提供商显示选项
+PROVIDER_CHOICES = [
+    ("deepseek", "🤖 DeepSeek"),
+    ("openai",   "🧠 OpenAI / 兼容格式"),
+    ("zhipu",    "🇨🇳 智谱 AI (GLM)"),
+    ("custom",   "🔧 自定义 API 地址"),
+]
+
+# provider -> (config_path, env_name)
+PROVIDER_KEY_PATHS = {
+    "deepseek": ("api.deepseek_key", "DEEPSEEK_API_KEY"),
+    "openai":   ("api.openai_key",   "OPENAI_API_KEY"),
+    "zhipu":    ("api.zhipu_key",    "ZHIPU_API_KEY"),
+    "custom":   ("api.custom_key",   "CUSTOM_API_KEY"),
+}
+
+
 class ConfigWizardV2:
-    """增强版配置向导 V2 - 包含管理功能"""
+    """增强版配置向导 V2 - 支持多模型提供商选择"""
 
     def __init__(self, root=None):
         self.own_root = False
@@ -25,103 +44,263 @@ class ConfigWizardV2:
             self.root.grab_set()
 
         self.root.title("Butler 配置向导 V2")
-        self.root.geometry("700x750")
+        self.root.geometry("760x820")
         self.root.configure(bg='#1c1c1c')
 
         self.backup_manager = ConfigBackupManager()
         self.validator = APIValidator()
 
-        # API 字段定义
-        self.api_fields = [
-            ("DEEPSEEK_API_KEY", "🤖 DeepSeek API Key:", True),
+        # 提供商选择变量
+        self.provider_var = tk.StringVar(value="deepseek")
+
+        # 基础字段（不随提供商变化）
+        self.base_fields = [
             ("BAIDU_APP_ID", "🎤 Baidu App ID:", False),
             ("BAIDU_API_KEY", "🎤 Baidu API Key:", False),
             ("BAIDU_SECRET_KEY", "🎤 Baidu Secret Key:", False),
             ("PICOVOICE_ACCESS_KEY", "🎙️ Picovoice Access Key:", False),
         ]
+
+        # 动态字段容器
         self.entries = {}
         self.status_labels = {}
 
         self._setup_ui()
         self._load_current_values()
 
+    # ---------- UI 构建 ----------
     def _setup_ui(self):
-        # 样式
         style = ttk.Style()
         style.theme_use('default')
         style.configure("TNotebook", background='#1c1c1c', borderwidth=0)
         style.configure("TNotebook.Tab", background='#333333', foreground='#ffffff', padding=[10, 5])
-        style.map("TNotebook.Tab", background=[("selected", "#00ff00")], foreground=[("selected", "#000000")])
+        style.map("TNotebook.Tab",
+                  background=[("selected", "#00ff00")],
+                  foreground=[("selected", "#000000")])
 
-        # 主框架
         main_frame = tk.Frame(self.root, bg='#1c1c1c')
         main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
-        # 标签页
         self.notebook = ttk.Notebook(main_frame)
         self.notebook.pack(fill=tk.BOTH, expand=True)
 
-        # Tab 1: API 配置
         self.api_tab = tk.Frame(self.notebook, bg='#1c1c1c')
         self.notebook.add(self.api_tab, text=" 🔑 API 配置 ")
         self._setup_api_tab()
 
-        # Tab 2: 管理功能
         self.mgmt_tab = tk.Frame(self.notebook, bg='#1c1c1c')
         self.notebook.add(self.mgmt_tab, text=" 🛠️ 管理工具 ")
         self._setup_mgmt_tab()
 
-        # 底部按钮区
         bottom_frame = tk.Frame(main_frame, bg='#1c1c1c')
         bottom_frame.pack(fill=tk.X, pady=10)
 
-        self.save_btn = tk.Button(bottom_frame, text="✅ 保存并应用", command=self.save_config,
-                                 bg='#00aa00', fg='#000000', font=("Arial", 10, "bold"),
-                                 padx=20, pady=8, borderwidth=0, cursor="hand2")
+        self.save_btn = tk.Button(bottom_frame, text="✅ 保存并应用",
+                                  command=self.save_config,
+                                  bg='#00aa00', fg='#000000',
+                                  font=("Arial", 10, "bold"),
+                                  padx=20, pady=8, borderwidth=0,
+                                  cursor="hand2")
         self.save_btn.pack(side=tk.RIGHT, padx=5)
 
-        self.close_btn = tk.Button(bottom_frame, text="关闭", command=self.root.destroy,
-                                  bg='#444444', fg='#ffffff', font=("Arial", 10),
-                                  padx=20, pady=8, borderwidth=0, cursor="hand2")
+        self.close_btn = tk.Button(bottom_frame, text="关闭",
+                                   command=self.root.destroy,
+                                   bg='#444444', fg='#ffffff',
+                                   font=("Arial", 10),
+                                   padx=20, pady=8, borderwidth=0,
+                                   cursor="hand2")
         self.close_btn.pack(side=tk.RIGHT, padx=5)
 
     def _setup_api_tab(self):
         content = tk.Frame(self.api_tab, bg='#1c1c1c', padx=20, pady=20)
         content.pack(fill=tk.BOTH, expand=True)
 
-        tk.Label(content, text="配置您的 API 密钥以启用核心功能",
-                 bg='#1c1c1c', fg='#00ff00', font=("Arial", 12, "bold")).pack(anchor='w', pady=(0, 20))
+        tk.Label(content, text="配置您的 API 以启用核心 AI 功能",
+                 bg='#1c1c1c', fg='#00ff00',
+                 font=("Arial", 12, "bold")).pack(anchor='w', pady=(0, 15))
 
-        form = tk.Frame(content, bg='#1c1c1c')
-        form.pack(fill=tk.X)
+        # ---- ① 提供商选择 ----
+        provider_box = tk.LabelFrame(content, text="① 选择 AI 模型服务商",
+                                     bg='#1c1c1c', fg='#00ff00',
+                                     font=("Arial", 10, "bold"),
+                                     padx=12, pady=10,
+                                     labelanchor='nw', relief=tk.GROOVE)
+        provider_box.pack(fill=tk.X, pady=(0, 12))
 
-        for i, (key, label, required) in enumerate(self.api_fields):
-            lbl = tk.Label(form, text=label + (" *" if required else ""),
-                          bg='#1c1c1c', fg='#ffffff', width=25, anchor='w')
-            lbl.grid(row=i, column=0, pady=10, sticky='w')
+        pv_row = tk.Frame(provider_box, bg='#1c1c1c')
+        pv_row.pack(fill=tk.X)
+        for i, (pid, label) in enumerate(PROVIDER_CHOICES):
+            tk.Radiobutton(pv_row, text=label, variable=self.provider_var,
+                           value=pid, bg='#1c1c1c', fg='#ffffff',
+                           selectcolor='#1c1c1c', activebackground='#1c1c1c',
+                           activeforeground='#00ff00', font=("Arial", 10, "bold"),
+                           cursor="hand2",
+                           command=self._on_provider_change).grid(
+                row=0, column=i, padx=8, sticky='w')
 
-            ent = tk.Entry(form, bg='#000000', fg='#00ff00', insertbackground='#00ff00',
-                          width=40, font=("Arial", 10))
-            ent.grid(row=i, column=1, pady=10, sticky='ew')
+        # ---- ② AI 配置动态区 ----
+        self.ai_cfg_frame = tk.LabelFrame(content,
+                                          text="② AI 服务商配置 (API 地址 / 模型 / 密钥)",
+                                          bg='#1c1c1c', fg='#00ff00',
+                                          font=("Arial", 10, "bold"),
+                                          padx=12, pady=10,
+                                          labelanchor='nw', relief=tk.GROOVE)
+        self.ai_cfg_frame.pack(fill=tk.X, pady=(0, 12))
+        self._build_ai_provider_fields()
+
+        # ---- ③ 其他服务 ----
+        other_box = tk.LabelFrame(content, text="③ 其他服务 (可选)",
+                                  bg='#1c1c1c', fg='#00ff00',
+                                  font=("Arial", 10, "bold"),
+                                  padx=12, pady=10,
+                                  labelanchor='nw', relief=tk.GROOVE)
+        other_box.pack(fill=tk.X, pady=(0, 12))
+
+        other_form = tk.Frame(other_box, bg='#1c1c1c')
+        other_form.pack(fill=tk.X)
+
+        for i, (key, label, required) in enumerate(self.base_fields):
+            lbl = tk.Label(other_form, text=label, bg='#1c1c1c', fg='#ffffff',
+                          width=30, anchor='w')
+            lbl.grid(row=i, column=0, pady=6, sticky='w')
+
+            ent = tk.Entry(other_form, bg='#000000', fg='#00ff00',
+                          insertbackground='#00ff00', width=40,
+                          font=("Arial", 10))
+            ent.grid(row=i, column=1, pady=6, sticky='ew')
             self.entries[key] = ent
 
-            status = tk.Label(form, text="○", bg='#1c1c1c', fg='#888888', font=("Arial", 12))
-            status.grid(row=i, column=2, padx=10)
+            status = tk.Label(other_form, text="○", bg='#1c1c1c', fg='#888888',
+                             font=("Arial", 12))
+            status.grid(row=i, column=2, padx=8)
             self.status_labels[key] = status
+
+        other_form.columnconfigure(1, weight=1)
+
+        # ---- 按钮 & 结果 ----
+        btn_row = tk.Frame(content, bg='#1c1c1c')
+        btn_row.pack(fill=tk.X, pady=(5, 10))
+
+        tk.Button(btn_row, text="🧪 批量验证 API", command=self.run_validation,
+                  bg='#0078d4', fg='#ffffff', padx=15, pady=5,
+                  borderwidth=0).pack(side=tk.LEFT)
+
+        self.result_box = scrolledtext.ScrolledText(content, height=8,
+                                                    bg='#000000', fg='#00ff00',
+                                                    font=("Courier", 9),
+                                                    borderwidth=0)
+        self.result_box.pack(fill=tk.BOTH, expand=True, pady=(5, 0))
+
+    def _build_ai_provider_fields(self):
+        """重建 AI 提供商相关的表单字段（provider 切换时调用）。"""
+        for w in self.ai_cfg_frame.winfo_children():
+            w.destroy()
+
+        pid = self.provider_var.get()
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+        display_name = defaults["display_name"]
+        default_url = defaults["base_url"] or ""
+        default_model = defaults["model_name"] or ""
+        key_env = defaults["key_env"]
+
+        form = tk.Frame(self.ai_cfg_frame, bg='#1c1c1c')
+        form.pack(fill=tk.X)
+
+        required_custom = (pid == "custom")
+        row_i = 0
+
+        # --- base_url ---
+        url_label = f"🌐 API 基础地址{' *' if required_custom else ' (可选)'}:"
+        tk.Label(form, text=url_label, bg='#1c1c1c', fg='#ffffff',
+                width=30, anchor='w').grid(row=row_i, column=0, pady=6, sticky='w')
+
+        ent_url = tk.Entry(form, bg='#000000', fg='#00ff00',
+                          insertbackground='#00ff00', width=40,
+                          font=("Arial", 10))
+        ent_url.grid(row=row_i, column=1, pady=6, sticky='ew')
+
+        if default_url and not required_custom:
+            url_hint = f"留空使用默认：{default_url}"
+        else:
+            url_hint = "例如: http://localhost:11434/v1"
+        tk.Label(form, text=url_hint, bg='#1c1c1c', fg='#66aa66',
+                font=("Arial", 8)).grid(row=row_i, column=2, padx=8, sticky='w')
+        self.entries["_AI_BASE_URL"] = ent_url
+        row_i += 1
+
+        # --- model_name ---
+        model_label = f"📋 模型名称{' *' if required_custom else ' (可选)'}:"
+        tk.Label(form, text=model_label, bg='#1c1c1c', fg='#ffffff',
+                width=30, anchor='w').grid(row=row_i, column=0, pady=6, sticky='w')
+
+        ent_model = tk.Entry(form, bg='#000000', fg='#00ff00',
+                            insertbackground='#00ff00', width=40,
+                            font=("Arial", 10))
+        ent_model.grid(row=row_i, column=1, pady=6, sticky='ew')
+
+        if default_model and not required_custom:
+            model_hint = f"留空使用默认：{default_model}"
+        else:
+            model_hint = "例如: qwen2.5:7b"
+        tk.Label(form, text=model_hint, bg='#1c1c1c', fg='#66aa66',
+                font=("Arial", 8)).grid(row=row_i, column=2, padx=8, sticky='w')
+        self.entries["_AI_MODEL_NAME"] = ent_model
+        row_i += 1
+
+        # --- api_key ---
+        key_label = f"🔑 {display_name} API Key *:"
+        tk.Label(form, text=key_label, bg='#1c1c1c', fg='#ffffff',
+                width=30, anchor='w').grid(row=row_i, column=0, pady=6, sticky='w')
+
+        ent_key = tk.Entry(form, bg='#000000', fg='#00ff00',
+                          insertbackground='#00ff00', width=40,
+                          font=("Arial", 10))
+        ent_key.grid(row=row_i, column=1, pady=6, sticky='ew')
+
+        tk.Label(form, text=f"保存到 {key_env}", bg='#1c1c1c', fg='#66aa66',
+                font=("Arial", 8)).grid(row=row_i, column=2, padx=8, sticky='w')
+
+        self.entries["_AI_API_KEY"] = ent_key
+        status_key = tk.Label(form, text="○", bg='#1c1c1c', fg='#888888',
+                             font=("Arial", 12))
+        status_key.grid(row=row_i, column=3, padx=8)
+        self.status_labels["_AI_API_KEY"] = status_key
 
         form.columnconfigure(1, weight=1)
 
-        btn_row = tk.Frame(content, bg='#1c1c1c')
-        btn_row.pack(fill=tk.X, pady=20)
+        # --- 预填已有值 ---
+        current_base = config_manager.get("api.base_url") or os.getenv("API_BASE_URL", "")
+        if current_base:
+            ent_url.insert(0, current_base)
 
-        tk.Button(btn_row, text="🧪 批量验证 API", command=self.run_validation,
-                  bg='#0078d4', fg='#ffffff', padx=15, pady=5, borderwidth=0).pack(side=tk.LEFT)
+        current_model = config_manager.get("api.model_name") or os.getenv("MODEL_NAME", "")
+        if current_model:
+            ent_model.insert(0, current_model)
 
-        # 结果显示
-        self.result_box = scrolledtext.ScrolledText(content, height=10, bg='#000000', fg='#00ff00',
-                                                   font=("Courier", 9), borderwidth=0)
-        self.result_box.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
+        cfg_path, env_name = PROVIDER_KEY_PATHS.get(pid, PROVIDER_KEY_PATHS["deepseek"])
+        current_key = config_manager.get(cfg_path) or os.getenv(env_name, "")
+        if current_key and "YOUR_" not in current_key:
+            ent_key.insert(0, current_key)
 
+    def _on_provider_change(self):
+        self._build_ai_provider_fields()
+
+    def _load_current_values(self):
+        cur_provider = config_manager.get("api.provider") or os.getenv("AI_PROVIDER", "deepseek")
+        if cur_provider in [p[0] for p in PROVIDER_CHOICES]:
+            self.provider_var.set(cur_provider)
+        self._on_provider_change()
+
+        for key, _, _ in self.base_fields:
+            ent = self.entries.get(key)
+            if not ent:
+                continue
+            val = config_manager.get(f"api.{key.lower()}") or os.getenv(key, "")
+            if "YOUR_" in str(val):
+                val = ""
+            ent.insert(0, str(val))
+
+    # ---------- 管理工具 Tab ----------
     def _setup_mgmt_tab(self):
         content = tk.Frame(self.mgmt_tab, bg='#1c1c1c', padx=20, pady=20)
         content.pack(fill=tk.BOTH, expand=True)
@@ -145,10 +324,14 @@ class ConfigWizardV2:
         btn_col = tk.Frame(content, bg='#1c1c1c')
         btn_col.pack(fill=tk.X)
 
-        tk.Button(btn_col, text="创建备份", command=self.create_backup, bg='#444444', fg='#ffffff').pack(side=tk.LEFT, padx=2)
-        tk.Button(btn_col, text="恢复选中", command=self.restore_backup, bg='#444444', fg='#ffffff').pack(side=tk.LEFT, padx=2)
-        tk.Button(btn_col, text="删除选中", command=self.delete_backup, bg='#a30000', fg='#ffffff').pack(side=tk.LEFT, padx=2)
-        tk.Button(btn_col, text="刷新列表", command=self.refresh_backups, bg='#444444', fg='#ffffff').pack(side=tk.LEFT, padx=2)
+        tk.Button(btn_col, text="创建备份", command=self.create_backup,
+                  bg='#444444', fg='#ffffff').pack(side=tk.LEFT, padx=2)
+        tk.Button(btn_col, text="恢复选中", command=self.restore_backup,
+                  bg='#444444', fg='#ffffff').pack(side=tk.LEFT, padx=2)
+        tk.Button(btn_col, text="删除选中", command=self.delete_backup,
+                  bg='#a30000', fg='#ffffff').pack(side=tk.LEFT, padx=2)
+        tk.Button(btn_col, text="刷新列表", command=self.refresh_backups,
+                  bg='#444444', fg='#ffffff').pack(side=tk.LEFT, padx=2)
 
         # 导入导出区
         tk.Label(content, text="📦 导入与导出", bg='#1c1c1c', fg='#00ff00',
@@ -169,62 +352,178 @@ class ConfigWizardV2:
         danger_frame = tk.Frame(content, bg='#331111', padx=10, pady=10)
         danger_frame.pack(fill=tk.X)
 
-        tk.Label(danger_frame, text="重置功能将删除当前所有配置并恢复到初始模板状态。",
+        tk.Label(danger_frame,
+                 text="重置功能将删除当前所有配置并恢复到初始模板状态。",
                  bg='#331111', fg='#cccccc', font=("Arial", 8)).pack(side=tk.LEFT)
         tk.Button(danger_frame, text="安全重置", command=self.perform_reset,
-                  bg='#ff4444', fg='#ffffff', font=("Arial", 9, "bold")).pack(side=tk.RIGHT)
+                  bg='#ff4444', fg='#ffffff',
+                  font=("Arial", 9, "bold")).pack(side=tk.RIGHT)
 
         self.refresh_backups()
 
-    def _load_current_values(self):
-        for key, entry in self.entries.items():
-            val = config_manager.get(f"api.{key.lower()}") or os.getenv(key, "")
-            if "YOUR_" in str(val):
-                val = ""
-            entry.insert(0, str(val))
+    # ---------- 读取表单值 ----------
+    def _get_entry_val(self, key):
+        ent = self.entries.get(key)
+        if ent is None:
+            return ""
+        try:
+            val = ent.get().strip()
+        except Exception:
+            return ""
+        return val
 
+    # ---------- 验证 ----------
     def run_validation(self):
         self.result_box.delete(1.0, tk.END)
-        self.result_box.insert(tk.END, "开始验证 API 密钥...\n" + "-"*40 + "\n")
+        self.result_box.insert(tk.END, "开始验证 API 配置...\n" + "-" * 40 + "\n")
 
-        config = {k: v.get().strip() for k, v in self.entries.items()}
+        pid = self.provider_var.get()
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+        display_name = defaults["display_name"]
+
+        base_url = self._get_entry_val("_AI_BASE_URL") or defaults["base_url"]
+        model = self._get_entry_val("_AI_MODEL_NAME") or defaults["model_name"]
+        api_key = self._get_entry_val("_AI_API_KEY")
+
+        base_url = base_url.rstrip("/") if base_url else ""
+        url = f"{base_url}/chat/completions" if base_url else ""
+
+        self.result_box.insert(tk.END, f"\n📍 服务商: {display_name}")
+        self.result_box.insert(tk.END, f"\n📍 URL: {url or '(空)'}")
+        self.result_box.insert(tk.END, f"\n📍 模型: {model or '(空)'}")
+        self.result_box.insert(tk.END, f"\n📍 密钥: {'已填写' if api_key and 'YOUR_' not in api_key else '未填写'}\n")
+
+        config = {k: self._get_entry_val(k) for k, _, _ in self.base_fields}
+        config["_AI_PROVIDER"] = pid
+        config["_AI_URL"] = url
+        config["_AI_MODEL"] = model
+        config["_AI_KEY"] = api_key
 
         def _task():
-            results = self.validator.validate_all(config)
-            self.root.after(0, lambda: self._update_validation_ui(results))
+            # AI 通用验证
+            ai_ok = False
+            if api_key and "YOUR_" not in api_key and url:
+                self.result_box.insert(tk.END, f"\n🧪 测试 {display_name} API ...")
+                self.root.update()
+                r = self._validate_any_provider(url, api_key, model)
+                if r.get("valid"):
+                    self.result_box.insert(tk.END, " ✅\n")
+                    ai_ok = True
+                    if "_AI_API_KEY" in self.status_labels:
+                        self.status_labels["_AI_API_KEY"].config(text="✅", fg="#00ff00")
+                else:
+                    self.result_box.insert(tk.END, f" ❌  {r.get('error', '未知错误')}\n")
+                    if "_AI_API_KEY" in self.status_labels:
+                        self.status_labels["_AI_API_KEY"].config(text="❌", fg="#ff4444")
+            elif not api_key or "YOUR_" in api_key:
+                self.result_box.insert(tk.END, "\n⚠️ AI API Key 未填写或为占位符。\n")
+
+            # Baidu 简单校验 (长度)
+            for env_key, label, _ in self.base_fields:
+                v = config.get(env_key, "")
+                lbl = self.status_labels.get(env_key)
+                if v and len(v) >= 5:
+                    self.result_box.insert(tk.END, f"OK  - {env_key} (格式校验通过)\n")
+                    if lbl:
+                        lbl.config(text="✅", fg="#00ff00")
+                elif v:
+                    self.result_box.insert(tk.END, f"ERR - {env_key} (长度可能不足)\n")
+                    if lbl:
+                        lbl.config(text="❌", fg="#ff4444")
+
+            self.result_box.insert(tk.END, "\n验证完成。")
 
         threading.Thread(target=_task, daemon=True).start()
 
-    def _update_validation_ui(self, results: Dict[str, Any]):
-        for key, res in results.items():
-            status_lbl = self.status_labels.get(key)
-            if res.get('valid'):
-                status_lbl.config(text="✅", fg='#00ff00')
-                self.result_box.insert(tk.END, f"OK  - {key}\n")
+    def _validate_any_provider(self, url, api_key, model):
+        import requests as _req
+        try:
+            r = _req.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json"
+                },
+                json={
+                    "model": model,
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                    "temperature": 0,
+                },
+                timeout=10,
+            )
+            if r.status_code == 200:
+                data = r.json()
+                if "choices" in data:
+                    return {"valid": True}
+                return {"valid": False, "error": f"响应格式异常: {str(data)[:100]}"}
+            elif r.status_code == 401:
+                return {"valid": False, "error": "认证失败 (401)：密钥无效"}
+            elif r.status_code == 404:
+                return {"valid": False, "error": f"地址 404：{url}"}
+            elif r.status_code == 429:
+                return {"valid": False, "error": "请求过于频繁 (429)"}
             else:
-                status_lbl.config(text="❌", fg='#ff4444')
-                err = res.get('error', '未知错误')
-                self.result_box.insert(tk.END, f"ERR - {key}: {err}\n")
+                try:
+                    msg = r.json()
+                except Exception:
+                    msg = r.text
+                return {"valid": False, "error": f"HTTP {r.status_code}: {str(msg)[:150]}"}
+        except _req.exceptions.Timeout:
+            return {"valid": False, "error": "连接超时"}
+        except _req.exceptions.ConnectionError:
+            return {"valid": False, "error": "网络连接失败，请检查地址/端口"}
+        except Exception as e:
+            return {"valid": False, "error": str(e)}
 
-        self.result_box.insert(tk.END, "\n验证完成。")
-
+    # ---------- 保存 ----------
     def save_config(self):
-        for key, entry in self.entries.items():
-            val = entry.get().strip()
+        pid = self.provider_var.get()
+        defaults = PROVIDER_DEFAULTS.get(pid, PROVIDER_DEFAULTS["deepseek"])
+        key_env = defaults["key_env"]
+        display_name = defaults["display_name"]
 
-            # 简单映射 key
-            path = f"api.{key.lower()}"
-            if key == "DEEPSEEK_API_KEY": path = "api.deepseek_key"
-            elif key == "BAIDU_APP_ID": path = "api.baidu_app_id"
-            elif key == "BAIDU_API_KEY": path = "api.baidu_api_key"
-            elif key == "BAIDU_SECRET_KEY": path = "api.baidu_secret_key"
+        base_url = self._get_entry_val("_AI_BASE_URL")
+        model_name = self._get_entry_val("_AI_MODEL_NAME")
+        api_key = self._get_entry_val("_AI_API_KEY")
 
-            # 即使为空也保存（允许清除）
-            config_manager.set(path, val)
+        # 简单校验
+        if not api_key or "YOUR_" in api_key:
+            messagebox.showerror("错误", f"{display_name} API Key 是必需的！")
+            return
+        if pid == "custom":
+            if not base_url:
+                messagebox.showerror("错误", "自定义模式下 API 基础地址是必需的！")
+                return
+            if not model_name:
+                messagebox.showerror("错误", "自定义模式下模型名称是必需的！")
+                return
 
-        messagebox.showinfo("成功", "配置已保存。部分更改可能需要重启程序。")
+        try:
+            # Provider / URL / Model
+            config_manager.set("api.provider", pid, persist=True)
+            config_manager.set("api.base_url", base_url, persist=True)
+            config_manager.set("api.model_name", model_name, persist=True)
 
-    # 备份管理逻辑
+            # 当前 provider 的 key
+            cfg_path, _ = PROVIDER_KEY_PATHS.get(pid, PROVIDER_KEY_PATHS["deepseek"])
+            config_manager.set(cfg_path, api_key, persist=True)
+
+            # 其他字段
+            for key, _, _ in self.base_fields:
+                val = self._get_entry_val(key)
+                config_manager.set(f"api.{key.lower()}", val, persist=True)
+
+            messagebox.showinfo("成功",
+                                f"✅ 配置已保存！\n\n"
+                                f"提供商: {display_name}\n"
+                                f"密钥保存至: {key_env}\n\n"
+                                f"部分更改可能需要重启程序。")
+        except Exception as e:
+            messagebox.showerror("保存失败", f"无法保存配置：{str(e)}")
+            logger.error(f"Failed to save config: {e}")
+
+    # ---------- 备份管理 ----------
     def refresh_backups(self):
         self.backup_list.delete(0, tk.END)
         self.backups_data = self.backup_manager.list_backups()
@@ -239,10 +538,11 @@ class ConfigWizardV2:
 
     def restore_backup(self):
         idx = self.backup_list.curselection()
-        if not idx: return
-
+        if not idx:
+            return
         backup_name = self.backups_data[idx[0]]['name']
-        if messagebox.askyesno("确认", f"确定要恢复备份 {backup_name} 吗？当前配置将被覆盖。"):
+        if messagebox.askyesno("确认",
+                               f"确定要恢复备份 {backup_name} 吗？当前配置将被覆盖。"):
             if self.backup_manager.restore_backup(backup_name):
                 messagebox.showinfo("成功", "配置已恢复，请重启程序。")
                 config_manager.reload()
@@ -250,14 +550,15 @@ class ConfigWizardV2:
 
     def delete_backup(self):
         idx = self.backup_list.curselection()
-        if not idx: return
-
+        if not idx:
+            return
         backup_name = self.backups_data[idx[0]]['name']
         if self.backup_manager.delete_backup(backup_name):
             self.refresh_backups()
 
     def export_zip(self):
-        path = filedialog.asksaveasfilename(defaultextension=".zip", filetypes=[("ZIP files", "*.zip")])
+        path = filedialog.asksaveasfilename(defaultextension=".zip",
+                                             filetypes=[("ZIP files", "*.zip")])
         if path:
             if self.backup_manager.export_config(path):
                 messagebox.showinfo("成功", f"配置已导出至 {path}")
@@ -278,6 +579,7 @@ class ConfigWizardV2:
                 config_manager.reload()
                 self._load_current_values()
                 self.refresh_backups()
+
 
 if __name__ == "__main__":
     wizard = ConfigWizardV2()

--- a/butler/gui/config_wizard_enhanced_v2.py
+++ b/butler/gui/config_wizard_enhanced_v2.py
@@ -7,7 +7,7 @@ from typing import Dict, Any, List
 from butler.core.api_validator import APIValidator
 from butler.core.config_backup_manager import ConfigBackupManager
 from butler.core.config_manager import config_manager
-from butler.core.config_model import PROVIDER_DEFAULTS
+from butler.core.config_model import PROVIDER_DEFAULTS, PROVIDER_KEY_PATHS
 from package.core_utils.log_manager import LogManager
 
 logger = LogManager.get_logger(__name__)
@@ -15,19 +15,15 @@ logger = LogManager.get_logger(__name__)
 
 # 提供商显示选项
 PROVIDER_CHOICES = [
-    ("deepseek", "🤖 DeepSeek"),
-    ("openai",   "🧠 OpenAI / 兼容格式"),
-    ("zhipu",    "🇨🇳 智谱 AI (GLM)"),
-    ("custom",   "🔧 自定义 API 地址"),
+    ("deepseek",  "🤖 DeepSeek"),
+    ("openai",    "🧠 OpenAI / 兼容格式"),
+    ("zhipu",     "🇨🇳 智谱 AI (GLM)"),
+    ("anthropic", "🎭 Anthropic Claude"),
+    ("gemini",    "✨ Google Gemini"),
+    ("dashscope", "🇨🇳 通义千问 (Qwen)"),
+    ("qianfan",   "🇨🇳 百度文心一言 (ERNIE)"),
+    ("custom",    "🔧 自定义 API 地址"),
 ]
-
-# provider -> (config_path, env_name)
-PROVIDER_KEY_PATHS = {
-    "deepseek": ("api.deepseek_key", "DEEPSEEK_API_KEY"),
-    "openai":   ("api.openai_key",   "OPENAI_API_KEY"),
-    "zhipu":    ("api.zhipu_key",    "ZHIPU_API_KEY"),
-    "custom":   ("api.custom_key",   "CUSTOM_API_KEY"),
-}
 
 
 class ConfigWizardV2:
@@ -209,6 +205,22 @@ class ConfigWizardV2:
         required_custom = (pid == "custom")
         row_i = 0
 
+        # --- 自定义名称 (仅 custom) ---
+        if required_custom:
+            tk.Label(form, text="🏷️ 自定义名称（用于区分）:",
+                     bg='#1c1c1c', fg='#ffffff',
+                     width=30, anchor='w').grid(row=row_i, column=0, pady=6, sticky='w')
+
+            ent_name = tk.Entry(form, bg='#000000', fg='#00ff00',
+                                insertbackground='#00ff00', width=40,
+                                font=("Arial", 10))
+            ent_name.grid(row=row_i, column=1, pady=6, sticky='ew')
+
+            tk.Label(form, text="例如: 我的Ollama", bg='#1c1c1c', fg='#66aa66',
+                    font=("Arial", 8)).grid(row=row_i, column=2, padx=8, sticky='w')
+            self.entries["CUSTOM_PROVIDER_NAME"] = ent_name
+            row_i += 1
+
         # --- base_url ---
         url_label = f"🌐 API 基础地址{' *' if required_custom else ' (可选)'}:"
         tk.Label(form, text=url_label, bg='#1c1c1c', fg='#ffffff',
@@ -269,6 +281,11 @@ class ConfigWizardV2:
         form.columnconfigure(1, weight=1)
 
         # --- 预填已有值 ---
+        if required_custom:
+            current_label = config_manager.get("api.provider_label") or os.getenv("CUSTOM_PROVIDER_NAME", "")
+            if current_label:
+                self.entries["CUSTOM_PROVIDER_NAME"].insert(0, current_label)
+
         current_base = config_manager.get("api.base_url") or os.getenv("API_BASE_URL", "")
         if current_base:
             ent_url.insert(0, current_base)
@@ -277,7 +294,7 @@ class ConfigWizardV2:
         if current_model:
             ent_model.insert(0, current_model)
 
-        cfg_path, env_name = PROVIDER_KEY_PATHS.get(pid, PROVIDER_KEY_PATHS["deepseek"])
+        cfg_path, env_name, _field = PROVIDER_KEY_PATHS.get(pid, PROVIDER_KEY_PATHS["deepseek"])
         current_key = config_manager.get(cfg_path) or os.getenv(env_name, "")
         if current_key and "YOUR_" not in current_key:
             ent_key.insert(0, current_key)
@@ -505,8 +522,12 @@ class ConfigWizardV2:
             config_manager.set("api.base_url", base_url, persist=True)
             config_manager.set("api.model_name", model_name, persist=True)
 
+            # 自定义提供商名称（CUSTOM_PROVIDER_NAME）
+            custom_name = self._get_entry_val("CUSTOM_PROVIDER_NAME")
+            config_manager.set("api.provider_label", custom_name, persist=True)
+
             # 当前 provider 的 key
-            cfg_path, _ = PROVIDER_KEY_PATHS.get(pid, PROVIDER_KEY_PATHS["deepseek"])
+            cfg_path, _, _field = PROVIDER_KEY_PATHS.get(pid, PROVIDER_KEY_PATHS["deepseek"])
             config_manager.set(cfg_path, api_key, persist=True)
 
             # 其他字段

--- a/butler/tui/main.py
+++ b/butler/tui/main.py
@@ -1466,21 +1466,52 @@ class ButlerTUI(App):
         content.mount(Label(settings_html))
 
     def _build_settings_html(self) -> str:
+        # 动态读取当前 AI 提供商配置
+        try:
+            from butler.core.config_model import PROVIDER_DEFAULTS, PROVIDER_KEY_PATHS
+            import os as _os
+            _provider = _os.getenv("AI_PROVIDER", "deepseek") or "deepseek"
+            _defaults = PROVIDER_DEFAULTS.get(_provider, PROVIDER_DEFAULTS["deepseek"])
+            _label = _os.getenv("CUSTOM_PROVIDER_NAME", "") or ""
+            _key_env = _defaults["key_env"]
+            _kv = _os.getenv(_key_env, "") or ""
+            if _kv and "YOUR_" not in _kv:
+                _key_status = f"{_kv[:4]}***（已配置）"
+            else:
+                _key_status = "未配置"
+            _name = _defaults["display_name"] + (f"（{_label}）" if _label else "")
+            _api_lines = [
+                "[bold]🔑 API 配置[/bold]",
+                f"  当前提供商: {_provider} ({_name})",
+                f"  密钥状态: {_key_env} = {_key_status}",
+                "  配置文件: config/config.yaml",
+                "  环境变量: .env",
+                "  [提示] 在终端运行 [bold]butler config[/bold] 可交互式切换服务商/填写密钥",
+                "         运行 [bold]butler config show[/bold] 查看当前配置\n",
+            ]
+        except Exception:
+            _api_lines = [
+                "[bold]🔑 API 配置[/bold]",
+                "  配置文件: config/config.yaml",
+                "  环境变量: .env",
+                "  [提示] 在终端运行 [bold]butler config[/bold] 配置 AI 服务商\n",
+            ]
+
         lines = [
             "[bold]⚙️ Butler 设置[/bold]\n",
             "[bold]🎨 主题[/bold]",
             "  当前: 默认深色",
             "  可选: dark, light, google, apple\n",
-            "[bold]🔑 API 配置[/bold]",
-            "  配置文件: config/config.yaml",
-            "  环境变量: .env\n",
+        ]
+        lines.extend(_api_lines)
+        lines.extend([
             "[bold]🔊 语音[/bold]",
             "  模式: offline",
             "  可选: offline, local, online\n",
             "[bold]💾 存储[/bold]",
             "  记忆后端: SQLite",
             "  数据目录: data/butler_memory/\n",
-        ]
+        ])
         return "\n".join(lines)
 
     @on(Tabs.TabActivated, "#view-settings Tabs")

--- a/butler_cli.py
+++ b/butler_cli.py
@@ -109,7 +109,11 @@ def main():
     # 13. 诊断 (Doctor)
     subparsers.add_parser("doctor", help="系统诊断与预检 (Doctor Mode)")
 
-    # 14. TUI 终端界面
+    # 14. 配置 AI 服务商 (config)
+    config_parser = subparsers.add_parser("config", help="交互式配置 AI 服务商与密钥")
+    config_parser.add_argument("sub", nargs='?', default="", help="子命令: show (查看当前配置)")
+
+    # 15. TUI 终端界面
     tui_parser = subparsers.add_parser("tui", help="启动 Butler TUI 终端用户界面")
     tui_parser.add_argument("--headless", action="store_true", help="无头模式 (仅 API 服务)")
 
@@ -245,6 +249,10 @@ def main():
         elif args.command == "doctor":
             from butler.core.doctor import run_doctor
             run_doctor()
+
+        elif args.command == "config":
+            from butler.cli.config_cmd import run_config
+            run_config(getattr(args, "sub", ""))
 
         elif args.command == "tui":
             from butler.tui.main import run_tui

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,15 +4,17 @@ api:
   # ============================================
   # AI 模型提供商配置
   # ============================================
-  # 提供商: deepseek | openai | zhipu | custom
+  # 提供商: deepseek | openai | zhipu | anthropic | gemini | dashscope | qianfan | custom
   provider: "${AI_PROVIDER:-deepseek}"
+  # 自定义提供商名称 (custom 时用于区分多个自定义配置)
+  provider_label: "${CUSTOM_PROVIDER_NAME:-}"
   # API 基础地址 (留空使用提供商默认)
   base_url: "${API_BASE_URL:-}"
   # 模型名称 (留空使用提供商默认)
   model_name: "${MODEL_NAME:-}"
 
   # ============================================
-  # API 密钥配置
+  # API 密钥配置 (仅需填写当前 provider 对应的密钥)
   # ============================================
   # DeepSeek API 密钥
   deepseek_key: "${DEEPSEEK_API_KEY:-}"
@@ -20,6 +22,14 @@ api:
   openai_key: "${OPENAI_API_KEY:-}"
   # 智谱 AI API 密钥
   zhipu_key: "${ZHIPU_API_KEY:-}"
+  # Anthropic Claude API 密钥
+  anthropic_key: "${ANTHROPIC_API_KEY:-}"
+  # Google Gemini API 密钥
+  gemini_key: "${GEMINI_API_KEY:-}"
+  # 通义千问 (DashScope) API 密钥
+  dashscope_key: "${DASHSCOPE_API_KEY:-}"
+  # 百度文心一言 (千帆) API 密钥
+  qianfan_key: "${QIANFAN_API_KEY:-}"
   # 自定义 API 密钥
   custom_key: "${CUSTOM_API_KEY:-}"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,28 @@
 # Butler 智能管家系统配置文件
 
 api:
+  # ============================================
+  # AI 模型提供商配置
+  # ============================================
+  # 提供商: deepseek | openai | zhipu | custom
+  provider: "${AI_PROVIDER:-deepseek}"
+  # API 基础地址 (留空使用提供商默认)
+  base_url: "${API_BASE_URL:-}"
+  # 模型名称 (留空使用提供商默认)
+  model_name: "${MODEL_NAME:-}"
+
+  # ============================================
+  # API 密钥配置
+  # ============================================
   # DeepSeek API 密钥
   deepseek_key: "${DEEPSEEK_API_KEY:-}"
+  # OpenAI API 密钥
+  openai_key: "${OPENAI_API_KEY:-}"
+  # 智谱 AI API 密钥
+  zhipu_key: "${ZHIPU_API_KEY:-}"
+  # 自定义 API 密钥
+  custom_key: "${CUSTOM_API_KEY:-}"
+
   # 百度语音 API 配置
   baidu_app_id: "${BAIDU_APP_ID:-}"
   baidu_api_key: "${BAIDU_API_KEY:-}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,16 +161,73 @@ if [ ! -f ".env" ]; then
     log_info "未检测到 .env 配置文件，正在以 .env.example 为模板克隆创建..."
     cp .env.example .env
 
-    # 检测外界是否通过命令行链式注入了 DEEPSEEK_API_KEY 等敏感变量
-    if [ -n "$DEEPSEEK_API_KEY" ]; then
-        log_info "捕获到链式声明的 ${CYAN}DEEPSEEK_API_KEY${NC}，正在自动完成无感写入..."
-        # 兼容 macOS 和 Linux 的 sed 替换
+    # ---- AI 提供商选择 (交互/链式注入二选一) ----
+    # 若通过环境变量直接声明 AI_PROVIDER 则跳过交互 (非交互管道部署)
+    if [ -z "$AI_PROVIDER" ] && [ -t 0 ]; then
+        echo ""
+        printf "${CYAN}${BOLD}请选择 AI 模型服务商：${NC}\n"
+        echo "  1) DeepSeek (默认)"
+        echo "  2) OpenAI / 兼容 OpenAI 格式"
+        echo "  3) 智谱 AI (GLM)"
+        echo "  4) 自定义 API 地址 (Ollama/本地部署)"
+        printf "请输入选项 [1-4，默认 1]: "
+        read -r _p_choice
+        _p_choice="${_p_choice:-1}"
+        case "$_p_choice" in
+            1) AI_PROVIDER="deepseek" ;;
+            2) AI_PROVIDER="openai" ;;
+            3) AI_PROVIDER="zhipu" ;;
+            4) AI_PROVIDER="custom"
+               printf "  请输入 API 基础地址 (例如 http://localhost:11434/v1): "; read -r API_BASE_URL
+               printf "  请输入模型名称 (例如 qwen2.5:7b): "; read -r MODEL_NAME ;;
+            *) AI_PROVIDER="deepseek" ;;
+        esac
+        echo ""
+    fi
+
+    # 写入 AI_PROVIDER (默认 deepseek)
+    AI_PROVIDER="${AI_PROVIDER:-deepseek}"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/^AI_PROVIDER=.*/AI_PROVIDER=$AI_PROVIDER/g" .env
+    else
+        sed -i "s/^AI_PROVIDER=.*/AI_PROVIDER=$AI_PROVIDER/g" .env
+    fi
+    log_info "AI 服务商已设置: ${CYAN}$AI_PROVIDER${NC}"
+
+    # 可选写入 API_BASE_URL / MODEL_NAME
+    if [ -n "$API_BASE_URL" ]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s/DEEPSEEK_API_KEY=.*/DEEPSEEK_API_KEY=\"$DEEPSEEK_API_KEY\"/g" .env
+            sed -i '' "s|^API_BASE_URL=.*|API_BASE_URL=$API_BASE_URL|g" .env
         else
-            sed -i "s/DEEPSEEK_API_KEY=.*/DEEPSEEK_API_KEY=\"$DEEPSEEK_API_KEY\"/g" .env
+            sed -i "s|^API_BASE_URL=.*|API_BASE_URL=$API_BASE_URL|g" .env
         fi
     fi
+    if [ -n "$MODEL_NAME" ]; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/^MODEL_NAME=.*/MODEL_NAME=$MODEL_NAME/g" .env
+        else
+            sed -i "s/^MODEL_NAME=.*/MODEL_NAME=$MODEL_NAME/g" .env
+        fi
+    fi
+
+    # ---- 自动写入对应 API Key (若通过环境变量链式注入) ----
+    _write_key() {
+        local env_name="$1"; local val="$2"
+        [ -z "$val" ] && return 0
+        log_info "捕获到链式声明的 ${CYAN}${env_name}${NC}，正在自动完成无感写入..."
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/${env_name}=.*/${env_name}=\"$val\"/g" .env
+        else
+            sed -i "s/${env_name}=.*/${env_name}=\"$val\"/g" .env
+        fi
+    }
+
+    case "$AI_PROVIDER" in
+        deepseek) _write_key "DEEPSEEK_API_KEY" "$DEEPSEEK_API_KEY" ;;
+        openai)   _write_key "OPENAI_API_KEY"   "$OPENAI_API_KEY"   ;;
+        zhipu)    _write_key "ZHIPU_API_KEY"    "$ZHIPU_API_KEY"    ;;
+        custom)   _write_key "CUSTOM_API_KEY"   "$CUSTOM_API_KEY"   ;;
+    esac
 else
     log_info ".env 配置文件已存在，跳过初始化，保留您的本地设置。"
 fi
@@ -230,8 +287,31 @@ echo -e "  1. 激活新终端环境后运行：   ${YELLOW}${BOLD}butler doctor$
 echo -e "  2. 立即启动核心服务：       ${YELLOW}${BOLD}butler start${NC}        (启动核心网关)"
 echo -e "  3. 委派特定 AI 角色执行任务： ${YELLOW}${BOLD}butler agent run demo-agent \"你的任务需求\"${NC}\n"
 
-if [ ! -f "$APP_DIR/.env" ] || ! grep -q "sk-" "$APP_DIR/.env"; then
-    log_warn "💡 提示: 检测到您尚未配置有效的 DeepSeek API 密钥。"
-    echo -e "   请编辑 ${BLUE}$APP_DIR/.env${NC} 文件填充 ${CYAN}DEEPSEEK_API_KEY=\"您的密钥\"${NC}，方可享受完整 AI 协同体验！\n"
+# 检测是否已配置对应 AI 服务商的有效密钥
+if [ -f "$APP_DIR/.env" ]; then
+    _prov=$(grep "^AI_PROVIDER=" "$APP_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '" ' || echo "deepseek")
+    case "$_prov" in
+        deepseek) _need="DEEPSEEK_API_KEY" ;;
+        openai)   _need="OPENAI_API_KEY"   ;;
+        zhipu)    _need="ZHIPU_API_KEY"    ;;
+        custom)   _need="CUSTOM_API_KEY"   ;;
+        *)        _need="DEEPSEEK_API_KEY" ;;
+    esac
+    # 检查是否已填写（排除 placeholder 和空值）
+    if ! grep -q "${_need}=" "$APP_DIR/.env" || grep -q "^${_need}=\"?YOUR_\|^${_need}=\"?\s*\"?$" "$APP_DIR/.env" 2>/dev/null; then
+        log_warn "💡 提示: 当前 AI 服务商 = ${CYAN}${_prov}${NC}，尚未配置有效的 ${_need}。"
+        echo -e "   请编辑 ${BLUE}$APP_DIR/.env${NC}，填充："
+        echo -e "     ${CYAN}AI_PROVIDER=${_prov}${NC}"
+        [ -n "$(grep "^API_BASE_URL=" "$APP_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d ' "')" ] || \
+            echo -e "     ${CYAN}API_BASE_URL=<你的API地址>${NC}   # 仅 custom/自定义时必须"
+        [ -n "$(grep "^MODEL_NAME=" "$APP_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d ' "')" ] || \
+            echo -e "     ${CYAN}MODEL_NAME=<模型名称>${NC}           # 仅 custom/自定义时必须"
+        echo -e "     ${CYAN}${_need}=\"您的_${_prov}_api_密钥\"${NC}   ← 在此输入您的密钥\n"
+    fi
+else
+    log_warn "💡 提示: 未检测到 .env 配置文件。"
+    echo -e "   请创建 ${BLUE}$APP_DIR/.env${NC} 并按以下结构填入您的配置："
+    echo -e "     ${CYAN}AI_PROVIDER=deepseek${NC}"
+    echo -e "     ${CYAN}DEEPSEEK_API_KEY=\"您的_deepseek_api_密钥\"${NC}\n"
 fi
 # ==============================================================================

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -169,15 +169,24 @@ if [ ! -f ".env" ]; then
         echo "  1) DeepSeek (默认)"
         echo "  2) OpenAI / 兼容 OpenAI 格式"
         echo "  3) 智谱 AI (GLM)"
-        echo "  4) 自定义 API 地址 (Ollama/本地部署)"
-        printf "请输入选项 [1-4，默认 1]: "
+        echo "  4) Anthropic Claude"
+        echo "  5) Google Gemini"
+        echo "  6) 通义千问 (DashScope)"
+        echo "  7) 百度文心一言 (千帆)"
+        echo "  8) 自定义 API 地址 (Ollama/本地部署)"
+        printf "请输入选项 [1-8，默认 1]: "
         read -r _p_choice
         _p_choice="${_p_choice:-1}"
         case "$_p_choice" in
             1) AI_PROVIDER="deepseek" ;;
             2) AI_PROVIDER="openai" ;;
             3) AI_PROVIDER="zhipu" ;;
-            4) AI_PROVIDER="custom"
+            4) AI_PROVIDER="anthropic" ;;
+            5) AI_PROVIDER="gemini" ;;
+            6) AI_PROVIDER="dashscope" ;;
+            7) AI_PROVIDER="qianfan" ;;
+            8) AI_PROVIDER="custom"
+               printf "  请输入自定义名称 (例如 我的Ollama): "; read -r CUSTOM_PROVIDER_NAME
                printf "  请输入 API 基础地址 (例如 http://localhost:11434/v1): "; read -r API_BASE_URL
                printf "  请输入模型名称 (例如 qwen2.5:7b): "; read -r MODEL_NAME ;;
             *) AI_PROVIDER="deepseek" ;;
@@ -194,20 +203,23 @@ if [ ! -f ".env" ]; then
     fi
     log_info "AI 服务商已设置: ${CYAN}$AI_PROVIDER${NC}"
 
-    # 可选写入 API_BASE_URL / MODEL_NAME
-    if [ -n "$API_BASE_URL" ]; then
+    # 可选写入 CUSTOM_PROVIDER_NAME / API_BASE_URL / MODEL_NAME
+    _safe_sed() {
+        local pattern="$1"
         if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s|^API_BASE_URL=.*|API_BASE_URL=$API_BASE_URL|g" .env
+            sed -i '' "$pattern" .env
         else
-            sed -i "s|^API_BASE_URL=.*|API_BASE_URL=$API_BASE_URL|g" .env
+            sed -i "$pattern" .env
         fi
+    }
+    if [ -n "$CUSTOM_PROVIDER_NAME" ]; then
+        _safe_sed "s/^CUSTOM_PROVIDER_NAME=.*/CUSTOM_PROVIDER_NAME=$CUSTOM_PROVIDER_NAME/g"
+    fi
+    if [ -n "$API_BASE_URL" ]; then
+        _safe_sed "s|^API_BASE_URL=.*|API_BASE_URL=$API_BASE_URL|g"
     fi
     if [ -n "$MODEL_NAME" ]; then
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s/^MODEL_NAME=.*/MODEL_NAME=$MODEL_NAME/g" .env
-        else
-            sed -i "s/^MODEL_NAME=.*/MODEL_NAME=$MODEL_NAME/g" .env
-        fi
+        _safe_sed "s/^MODEL_NAME=.*/MODEL_NAME=$MODEL_NAME/g"
     fi
 
     # ---- 自动写入对应 API Key (若通过环境变量链式注入) ----
@@ -215,18 +227,18 @@ if [ ! -f ".env" ]; then
         local env_name="$1"; local val="$2"
         [ -z "$val" ] && return 0
         log_info "捕获到链式声明的 ${CYAN}${env_name}${NC}，正在自动完成无感写入..."
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s/${env_name}=.*/${env_name}=\"$val\"/g" .env
-        else
-            sed -i "s/${env_name}=.*/${env_name}=\"$val\"/g" .env
-        fi
+        _safe_sed "s/${env_name}=.*/${env_name}=\"$val\"/g"
     }
 
     case "$AI_PROVIDER" in
-        deepseek) _write_key "DEEPSEEK_API_KEY" "$DEEPSEEK_API_KEY" ;;
-        openai)   _write_key "OPENAI_API_KEY"   "$OPENAI_API_KEY"   ;;
-        zhipu)    _write_key "ZHIPU_API_KEY"    "$ZHIPU_API_KEY"    ;;
-        custom)   _write_key "CUSTOM_API_KEY"   "$CUSTOM_API_KEY"   ;;
+        deepseek)  _write_key "DEEPSEEK_API_KEY"  "$DEEPSEEK_API_KEY"  ;;
+        openai)    _write_key "OPENAI_API_KEY"    "$OPENAI_API_KEY"    ;;
+        zhipu)     _write_key "ZHIPU_API_KEY"     "$ZHIPU_API_KEY"     ;;
+        anthropic) _write_key "ANTHROPIC_API_KEY" "$ANTHROPIC_API_KEY" ;;
+        gemini)    _write_key "GEMINI_API_KEY"    "$GEMINI_API_KEY"    ;;
+        dashscope) _write_key "DASHSCOPE_API_KEY" "$DASHSCOPE_API_KEY" ;;
+        qianfan)   _write_key "QIANFAN_API_KEY"   "$QIANFAN_API_KEY"   ;;
+        custom)    _write_key "CUSTOM_API_KEY"    "$CUSTOM_API_KEY"    ;;
     esac
 else
     log_info ".env 配置文件已存在，跳过初始化，保留您的本地设置。"
@@ -291,11 +303,15 @@ echo -e "  3. 委派特定 AI 角色执行任务： ${YELLOW}${BOLD}butler agent
 if [ -f "$APP_DIR/.env" ]; then
     _prov=$(grep "^AI_PROVIDER=" "$APP_DIR/.env" 2>/dev/null | cut -d'=' -f2 | tr -d '" ' || echo "deepseek")
     case "$_prov" in
-        deepseek) _need="DEEPSEEK_API_KEY" ;;
-        openai)   _need="OPENAI_API_KEY"   ;;
-        zhipu)    _need="ZHIPU_API_KEY"    ;;
-        custom)   _need="CUSTOM_API_KEY"   ;;
-        *)        _need="DEEPSEEK_API_KEY" ;;
+        deepseek)  _need="DEEPSEEK_API_KEY"  ;;
+        openai)    _need="OPENAI_API_KEY"    ;;
+        zhipu)     _need="ZHIPU_API_KEY"     ;;
+        anthropic) _need="ANTHROPIC_API_KEY" ;;
+        gemini)    _need="GEMINI_API_KEY"    ;;
+        dashscope) _need="DASHSCOPE_API_KEY" ;;
+        qianfan)   _need="QIANFAN_API_KEY"   ;;
+        custom)    _need="CUSTOM_API_KEY"    ;;
+        *)         _need="DEEPSEEK_API_KEY"  ;;
     esac
     # 检查是否已填写（排除 placeholder 和空值）
     if ! grep -q "${_need}=" "$APP_DIR/.env" || grep -q "^${_need}=\"?YOUR_\|^${_need}=\"?\s*\"?$" "$APP_DIR/.env" 2>/dev/null; then


### PR DESCRIPTION
## Summary by Sourcery

在 GUI、CLI、安装脚本和核心服务中添加统一的多供应商 AI 配置，包括支持自定义兼容 OpenAI 的端点以及动态密钥解析。

New Features:
- 引入可配置的 AI 提供商选择，内置 DeepSeek、OpenAI、Zhipu、Anthropic、Gemini、DashScope、Qianfan 以及自定义端点的预设。
- 添加交互式 CLI 命令，可在终端中配置 AI 提供商、API 基础 URL、模型和密钥。
- 扩展 GUI 配置向导，支持多步骤的提供商选择、自定义端点，以及通用的 API 校验。
- 在 TUI 设置视图和 config.yaml 中公开支持提供商感知的 AI 设置，包括动态的提供商、基础 URL、模型和密钥字段。

Enhancements:
- 重构 NLU 服务，通过集中配置动态解析不同提供商的 API 端点、模型和密钥。
- 在配置模型中集中管理提供商默认值和密钥映射，以便核心服务和 UI 流程复用。
- 改进配置管理器对与 API 相关的密钥的处理，并依据当前激活的提供商执行必需密钥校验。
- 更新安装脚本，以交互方式设置 AI 提供商，将相应密钥写入 `.env`，并提供针对不同提供商的安装后指引。
- 简化决定何时显示配置向导的逻辑，将必需密钥校验委托给 `config_manager`。

Build:
- 调整 `bin/install.sh` 和 `scripts/install.sh`，以创建包含支持不同提供商的 AI 字段、可选语音设置和 MQTT 默认值的 `.env` 文件。

Documentation:
- 增强 `config.yaml` 模板，向用户说明 AI 提供商选择、基础 URL/模型覆盖规则，以及各提供商对应的密钥字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unified multi-provider AI configuration across GUI, CLI, install scripts, and core services, including support for custom OpenAI-compatible endpoints and dynamic key resolution.

New Features:
- Introduce configurable AI provider selection with presets for DeepSeek, OpenAI, Zhipu, Anthropic, Gemini, DashScope, Qianfan, and custom endpoints.
- Add interactive CLI command to configure AI providers, API base URLs, models, and keys from the terminal.
- Extend GUI configuration wizards to support multi-step provider selection, custom endpoints, and generalized API validation.
- Expose provider-aware AI settings in the TUI settings view and config.yaml, including dynamic provider, base URL, model, and key fields.

Enhancements:
- Refactor NLU service to dynamically resolve provider-specific API endpoints, models, and keys using centralized configuration.
- Centralize provider defaults and key mappings in the config model for reuse by core services and UI flows.
- Improve config manager handling of API-related keys and required-key validation based on the active provider.
- Update install scripts to interactively set AI provider, write corresponding keys into .env, and give provider-specific post-install guidance.
- Simplify logic for deciding when to show the configuration wizard by delegating required-key validation to config_manager.

Build:
- Adjust bin/install.sh and scripts/install.sh to create .env with provider-aware AI fields, optional voice settings, and MQTT defaults.

Documentation:
- Enhance config.yaml template to document AI provider selection, base URL/model overrides, and per-provider key fields for users.

</details>