### PR TITLE
feat: Add AI Memory Service skill with MCP, FTS5+Zvec RRF, and handoff hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ temp_android_repo/
 .env_ready
 .tasks/
 
+# AI Memory runtime directories
+.butler-memory/
+butler-memory/
+
 # Executables and bin/ artifacts
 **/*_exec
 **/sysutil

--- a/butler/tui/command_catalog.py
+++ b/butler/tui/command_catalog.py
@@ -413,6 +413,24 @@ COMMANDS: list[CommandEntry] = [
         example="/memory",
     ),
     CommandEntry(
+        name="memory_save", aliases=["memsave", "m_save", "保存记忆"],
+        category="🧠 记忆",
+        description="保存 AI 记忆或会话交接",
+        usage="/memory_save <标题> | <内容> | [摘要]",
+        detail="将关键信息保存至 Markdown 源文件与 SQLite+Zvec 索引库。",
+        tags=["记忆", "memory", "保存", "save", "handoff", "交接"],
+        example="/memory_save 架构决策 | 采用 SQLite FTS5 + Zvec | 完成索引设计",
+    ),
+    CommandEntry(
+        name="memory_query", aliases=["memquery", "m_query", "查询记忆"],
+        category="🧠 记忆",
+        description="混合检索 (RRF) AI 历史记忆",
+        usage="/memory_query <关键词/语义问题>",
+        detail="通过 RRF 倒数排名融合算法搜寻长期记忆与交接记录。",
+        tags=["记忆", "memory", "查询", "query", "搜索", "search"],
+        example="/memory_query FTS5 架构",
+    ),
+    CommandEntry(
         name="profile", aliases=["pf", "画像", "习惯"],
         category="💬 对话",
         description="查看用户画像",
@@ -990,6 +1008,14 @@ FLAG_REGISTRY: dict[str, list[FlagDef]] = {
     "tasks": [],
     "team": [],
     "memory": [],
+    "memory_save": [
+        FlagDef("-t", "--title", "title", "记忆标题", required=True),
+        FlagDef("-c", "--content", "content", "记忆正文", required=True),
+        FlagDef("-s", "--summary", "session_summary", "会话摘要 (可选)", required=False),
+    ],
+    "memory_query": [
+        FlagDef("-q", "--query", "query", "搜索关键词或语义问题", required=True),
+    ],
     "profile": [],
     "exit": [],
 

--- a/package/core_utils/config_loader.py
+++ b/package/core_utils/config_loader.py
@@ -1,19 +1,24 @@
 import os
 import json
-import yaml
+try:
+    import yaml
+except ImportError:
+    yaml = None
 import re
 from typing import Any, Optional
 from pathlib import Path
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    load_dotenv = None
+
 from package.core_utils.log_manager import LogManager
 from butler.core.constants import PROJECT_ROOT, SYSTEM_CONFIG_YAML, SYSTEM_CONFIG_JSON
 from butler.core.config_model import ButlerConfig
 from pydantic import ValidationError
 
 logger = LogManager.get_logger(__name__)
-
-# Load environment variables once
-load_dotenv()
 
 class ConfigLoader:
     _instance = None
@@ -41,7 +46,7 @@ class ConfigLoader:
         config_data = {}
 
         # 1. Try YAML
-        if SYSTEM_CONFIG_YAML.exists():
+        if SYSTEM_CONFIG_YAML.exists() and yaml:
             try:
                 with open(SYSTEM_CONFIG_YAML, 'r', encoding='utf-8') as f:
                     content = f.read()
@@ -121,10 +126,12 @@ class ConfigLoader:
 
         try:
             SYSTEM_CONFIG_YAML.parent.mkdir(parents=True, exist_ok=True)
-            with open(SYSTEM_CONFIG_YAML, 'w', encoding='utf-8') as f:
-                # Save as YAML without env var expansion (to preserve structure, though env vars will be lost if not careful)
-                # Actually, standard practice is to save actual values.
-                yaml.dump(self._config_obj.model_dump(), f, allow_unicode=True, sort_keys=False)
+            if yaml:
+                with open(SYSTEM_CONFIG_YAML, 'w', encoding='utf-8') as f:
+                    yaml.dump(self._config_obj.model_dump(), f, allow_unicode=True, sort_keys=False)
+            else:
+                with open(SYSTEM_CONFIG_JSON, 'w', encoding='utf-8') as f:
+                    json.dump(self._config_obj.model_dump(), f, ensure_ascii=False, indent=2)
             return True
         except Exception as e:
             logger.error(f"Failed to save config: {e}")

--- a/package/core_utils/embedding_utils.py
+++ b/package/core_utils/embedding_utils.py
@@ -1,4 +1,7 @@
-import requests
+try:
+    import requests
+except ImportError:
+    requests = None
 
 try:
     import numpy as np
@@ -25,7 +28,7 @@ def get_embedding(text: str, api_key: str = None, offline: bool = False) -> Opti
     """
     获取向量嵌入。支持在线 (DeepSeek) 和离线 (简单哈希 fallback) 模式。
     """
-    if not offline and api_key:
+    if not offline and api_key and requests:
         headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
         try:
             response = requests.post(

--- a/skills/ai_memory/SKILL.md
+++ b/skills/ai_memory/SKILL.md
@@ -1,0 +1,40 @@
+# AI Memory Service (AI 记忆服务)
+
+基于 `ai-memory` 架构思想的本地 AI 记忆系统：
+- **事实来源 (Source of Truth)**：Markdown 文件 (`.butler-memory/YYYY-MM-DD-标题.md` 与 FrontMatter 元数据)。
+- **索引层 (Index Layer)**：SQLite FTS5 全文检索 + Zvec 嵌入式向量语义搜索。
+- **混合检索 (Hybrid Search)**：RRF (Reciprocal Rank Fusion) 倒数排名融合算法，无缝支持降级。
+- **协议与接口 (MCP Server)**：符合 MCP (Model Context Protocol JSON-RPC 2.0) 标准，可被 Claude Code、Cursor、Butler 外部客户端直接调用。
+
+---
+
+## 核心接口 (Actions)
+
+1. `search`: 混合检索记忆 (`query`, `limit`)
+2. `save`: 保存新记忆 (`title`, `content`, `session_summary`, `decisions`, `open_questions`, `project`, `tags`)
+3. `create_handoff`: 创建交接/接棒文档 (`project_name`, `session_summary`, `decisions`, `open_questions`)
+4. `get_latest_handoff`: 获取最近一次交接文档 (`project_name`)
+5. `index_file`: 对外部 Markdown 建立索引 (`file_path`)
+6. `session_start`: 会话开始生命周期 Hook
+7. `session_end`: 会话结束生命周期 Hook
+
+---
+
+## MCP 服务器启动
+
+```bash
+python -m skills.ai_memory.mcp_server
+```
+
+在 Claude Code / Cursor `mcpServers` 配置：
+
+```json
+{
+  "mcpServers": {
+    "butler-ai-memory": {
+      "command": "python3",
+      "args": ["-m", "skills.ai_memory.mcp_server"]
+    }
+  }
+}
+```

--- a/skills/ai_memory/__init__.py
+++ b/skills/ai_memory/__init__.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""
+AI Memory Skill Package
+提供基于 Markdown + SQLite FTS5 + Zvec + MCP 的自建 AI 记忆服务。
+"""
+
+import os
+import json
+from typing import Dict, Any, List, Optional
+from skills.ai_memory.memory_service import MemoryService
+from skills.ai_memory.data_model import MemoryDocument
+
+class AIMemorySkill:
+    """
+    AI 记忆技能控制单例
+    """
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(AIMemorySkill, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self, project_root: Optional[str] = None, api_key: Optional[str] = None):
+        if getattr(self, "_initialized", False):
+            return
+        self.service = MemoryService(project_root=project_root, api_key=api_key)
+        self._initialized = True
+
+
+def handle_request(action: str, **kwargs) -> Any:
+    """
+    Butler 技能通用调用入口
+    :param action: 操作指令 (search, save, create_handoff, get_latest_handoff, index_file, session_start, session_end)
+    """
+    project_root = kwargs.get("project_root") or os.getcwd()
+    api_key = kwargs.get("api_key")
+    skill = AIMemorySkill(project_root=project_root, api_key=api_key)
+    service = skill.service
+
+    if action == "search" or action == "memory_query":
+        query = kwargs.get("query") or kwargs.get("text", "")
+        limit = kwargs.get("limit", 5)
+        if not query:
+            return "错误：搜索查询不能为空。"
+        return service.hybrid_search(query, limit=limit)
+
+    elif action == "save" or action == "memory_save":
+        title = kwargs.get("title", "Untitled Memory")
+        content = kwargs.get("content", "")
+        summary = kwargs.get("session_summary", "")
+        decisions = kwargs.get("decisions", [])
+        questions = kwargs.get("open_questions", [])
+        project = kwargs.get("project", "default")
+        tags = kwargs.get("tags", ["ai-memory"])
+
+        doc = MemoryDocument(
+            title=title,
+            content=content,
+            session_summary=summary,
+            decisions=decisions,
+            open_questions=questions,
+            project=project,
+            tags=tags
+        )
+        saved_path = service.save_memory(doc)
+        return {"status": "success", "file_path": saved_path, "doc_id": doc.doc_id}
+
+    elif action == "create_handoff":
+        project_name = kwargs.get("project_name", "default")
+        summary = kwargs.get("session_summary", "")
+        decisions = kwargs.get("decisions", [])
+        questions = kwargs.get("open_questions", [])
+        title = kwargs.get("title", "Session Handoff")
+
+        doc = service.create_handoff(project_name, summary, decisions, questions, title=title)
+        return {"status": "success", "file_path": doc.file_path, "handoff_id": doc.doc_id}
+
+    elif action == "get_latest_handoff":
+        project_name = kwargs.get("project_name")
+        res = service.get_latest_handoff(project_name=project_name)
+        if not res:
+            return {"status": "not_found", "message": "未找到交接记录"}
+        return {"status": "success", "handoff": res}
+
+    elif action == "index_file":
+        file_path = kwargs.get("file_path", "")
+        doc = service.index_file(file_path)
+        if not doc:
+            return {"status": "error", "message": f"无法对文件建立索引: {file_path}"}
+        return {"status": "success", "doc_id": doc.doc_id, "title": doc.title}
+
+    elif action == "session_start":
+        # 会话开始生命周期钩子：读取最新交接记录
+        project_name = kwargs.get("project_name", "default")
+        res = service.get_latest_handoff(project_name=project_name)
+        if res:
+            return {
+                "status": "handoff_restored",
+                "summary": res.get("session_summary"),
+                "decisions": res.get("decisions"),
+                "open_questions": res.get("open_questions"),
+                "created_at": res.get("created_at")
+            }
+        return {"status": "no_previous_handoff"}
+
+    elif action == "session_end":
+        # 会话结束生命周期钩子：自动生成交接记录
+        project_name = kwargs.get("project_name", "default")
+        summary = kwargs.get("session_summary", "Session concluded automatically.")
+        decisions = kwargs.get("decisions", [])
+        questions = kwargs.get("open_questions", [])
+
+        doc = service.create_handoff(project_name, summary, decisions, questions, title="Auto Session End Handoff")
+        return {"status": "handoff_saved", "file_path": doc.file_path}
+
+    return f"未知 AI Memory 操作: {action}"

--- a/skills/ai_memory/data_model.py
+++ b/skills/ai_memory/data_model.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""
+AI Memory Data Model and Schema Specifications
+支持 Markdown 文件 (YAML FrontMatter + Body)、SQLite FTS5 索引与 Zvec 向量 Schema 定义。
+"""
+
+import os
+import re
+import json
+import time
+import datetime
+from typing import List, Dict, Any, Optional
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+class MemoryDocument:
+    """
+    表示一篇 AI 记忆文档 (包含 FrontMatter 元数据与 Markdown 正文)
+    """
+    def __init__(
+        self,
+        title: str,
+        project: str = "default",
+        session_summary: str = "",
+        decisions: Optional[List[str]] = None,
+        open_questions: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        content: str = "",
+        file_path: Optional[str] = None,
+        date: Optional[str] = None,
+        doc_id: Optional[str] = None
+    ):
+        self.doc_id = doc_id or f"mem_{int(time.time() * 1000)}"
+        self.title = title
+        self.project = project
+        self.session_summary = session_summary
+        self.decisions = decisions or []
+        self.open_questions = open_questions or []
+        self.tags = tags or []
+        self.content = content
+        self.file_path = file_path
+        self.date = date or datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    def to_frontmatter_markdown(self) -> str:
+        """格式化为带 FrontMatter 的 Markdown 内容"""
+        meta = {
+            "id": self.doc_id,
+            "title": self.title,
+            "date": self.date,
+            "project": self.project,
+            "tags": self.tags,
+            "session_summary": self.session_summary,
+            "decisions": self.decisions,
+            "open_questions": self.open_questions,
+        }
+
+        if yaml:
+            yaml_str = yaml.dump(meta, allow_unicode=True, sort_keys=False).strip()
+        else:
+            # Fallback simple YAML generator
+            yaml_lines = [
+                f"id: {self.doc_id}",
+                f"title: \"{self.title}\"",
+                f"date: \"{self.date}\"",
+                f"project: \"{self.project}\"",
+                f"tags: {json.dumps(self.tags, ensure_ascii=False)}",
+                f"session_summary: \"{self.session_summary}\"",
+                "decisions:",
+            ]
+            for d in self.decisions:
+                yaml_lines.append(f"  - \"{d}\"")
+            yaml_lines.append("open_questions:")
+            for q in self.open_questions:
+                yaml_lines.append(f"  - \"{q}\"")
+            yaml_str = "\n".join(yaml_lines)
+
+        return f"---\n{yaml_str}\n---\n\n{self.content.strip()}\n"
+
+    @classmethod
+    def from_markdown(cls, raw_text: str, file_path: Optional[str] = None) -> "MemoryDocument":
+        """从原生 Markdown 文本解析 FrontMatter 和 Body"""
+        fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)$", raw_text, re.DOTALL)
+        meta = {}
+        content = raw_text
+
+        if fm_match:
+            yaml_text, content = fm_match.group(1), fm_match.group(2)
+            if yaml:
+                try:
+                    meta = yaml.safe_load(yaml_text) or {}
+                except Exception:
+                    meta = {}
+            else:
+                # Basic line regex fallback parser
+                meta = {}
+                for line in yaml_text.splitlines():
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        meta[k.strip()] = v.strip().strip('"').strip("'")
+
+        # Extract values
+        doc_id = meta.get("id")
+        title = meta.get("title", "Untitled Memory")
+        project = meta.get("project", "default")
+        session_summary = meta.get("session_summary", "")
+        decisions = meta.get("decisions", [])
+        if isinstance(decisions, str):
+            try: decisions = json.loads(decisions)
+            except Exception: decisions = [decisions]
+        open_questions = meta.get("open_questions", [])
+        if isinstance(open_questions, str):
+            try: open_questions = json.loads(open_questions)
+            except Exception: open_questions = [open_questions]
+        tags = meta.get("tags", [])
+        if isinstance(tags, str):
+            try: tags = json.loads(tags)
+            except Exception: tags = [tags]
+        date = meta.get("date", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+
+        return cls(
+            doc_id=doc_id,
+            title=title,
+            project=project,
+            session_summary=session_summary,
+            decisions=decisions,
+            open_questions=open_questions,
+            tags=tags,
+            content=content,
+            file_path=file_path,
+            date=date
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.doc_id,
+            "title": self.title,
+            "project": self.project,
+            "session_summary": self.session_summary,
+            "decisions": self.decisions,
+            "open_questions": self.open_questions,
+            "tags": self.tags,
+            "content": self.content,
+            "file_path": self.file_path,
+            "date": self.date
+        }
+
+
+# SQLite 表结构与 FTS5 规范
+CREATE_MEMORIES_TABLE = """
+CREATE TABLE IF NOT EXISTS memories (
+    id TEXT PRIMARY KEY,
+    title TEXT,
+    project TEXT,
+    file_path TEXT UNIQUE,
+    content TEXT,
+    session_summary TEXT,
+    decisions TEXT,
+    open_questions TEXT,
+    tags TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+CREATE_MEMORIES_FTS_TABLE = """
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+    title,
+    content,
+    session_summary,
+    decisions,
+    open_questions,
+    tags,
+    content='memories',
+    content_rowid='rowid'
+);
+"""
+
+CREATE_FTS_TRIGGERS = """
+CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+  INSERT INTO memories_fts(rowid, title, content, session_summary, decisions, open_questions, tags)
+  VALUES (new.rowid, new.title, new.content, new.session_summary, new.decisions, new.open_questions, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+  INSERT INTO memories_fts(memories_fts, rowid, title, content, session_summary, decisions, open_questions, tags)
+  VALUES('delete', old.rowid, old.title, old.content, old.session_summary, old.decisions, old.open_questions, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+  INSERT INTO memories_fts(memories_fts, rowid, title, content, session_summary, decisions, open_questions, tags)
+  VALUES('delete', old.rowid, old.title, old.content, old.session_summary, old.decisions, old.open_questions, old.tags);
+  INSERT INTO memories_fts(rowid, title, content, session_summary, decisions, open_questions, tags)
+  VALUES (new.rowid, new.title, new.content, new.session_summary, new.decisions, new.open_questions, new.tags);
+END;
+"""

--- a/skills/ai_memory/manifest.json
+++ b/skills/ai_memory/manifest.json
@@ -1,0 +1,9 @@
+{
+  "skill_id": "ai_memory",
+  "name": "AI 记忆服务",
+  "description": "借鉴 ai-memory 架构思想，以 Markdown 为事实来源、SQLite FTS5 + Zvec 为索引层，提供 RRF 混合搜索与 MCP (JSON-RPC) 标准接口。",
+  "actions": ["search", "save", "create_handoff", "get_latest_handoff", "index_file", "session_start", "session_end"],
+  "keywords": ["记忆", "memory", "ai-memory", "mcp", "handoff", "交接", "上下文"],
+  "has_frontend": false,
+  "icon": "fa-brain"
+}

--- a/skills/ai_memory/mcp_server.py
+++ b/skills/ai_memory/mcp_server.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""
+Butler AI Memory MCP (Model Context Protocol) Server
+符合 MCP 规范 (JSON-RPC 2.0)，为 Claude Code、Cursor 等客户端提供标准化的 AI 记忆读写接口。
+"""
+
+import sys
+import json
+import logging
+from typing import Dict, Any, Optional
+
+from skills.ai_memory.memory_service import MemoryService
+from skills.ai_memory.data_model import MemoryDocument
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("mcp_memory_server")
+
+
+class MCPMemoryServer:
+    """
+    MCP (Model Context Protocol) JSON-RPC 2.0 服务器
+    """
+    def __init__(self, project_root: Optional[str] = None):
+        self.service = MemoryService(project_root=project_root)
+
+    def get_tool_definitions(self) -> list:
+        return [
+            {
+                "name": "search_memory",
+                "description": "通过 RRF 倒数排名融合算法（混合 SQLite FTS5 与 Zvec 向量检索）搜索 AI 历史记忆",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "搜索关键词或语义问题"},
+                        "limit": {"type": "integer", "description": "返回结果最大条目数 (默认 5)", "default": 5}
+                    },
+                    "required": ["query"]
+                }
+            },
+            {
+                "name": "save_memory",
+                "description": "保存一条新的 AI 记忆文档 (包含 YAML FrontMatter 与 Markdown 正文)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "记忆标题"},
+                        "content": {"type": "string", "description": "Markdown 详细正文"},
+                        "session_summary": {"type": "string", "description": "会话核心摘要"},
+                        "decisions": {"type": "array", "items": {"type": "string"}, "description": "决议事项列表"},
+                        "open_questions": {"type": "array", "items": {"type": "string"}, "description": "待决/遗留问题列表"},
+                        "project": {"type": "string", "description": "项目标识 (默认为当前项目)"},
+                        "tags": {"type": "array", "items": {"type": "string"}, "description": "标签列表"}
+                    },
+                    "required": ["title", "content"]
+                }
+            },
+            {
+                "name": "create_handoff",
+                "description": "生成当前会话的交接/接棒文档 (用于无缝切换 AI 助手或新会话)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project_name": {"type": "string", "description": "项目名称"},
+                        "session_summary": {"type": "string", "description": "本次会话主要工作与进展摘要"},
+                        "decisions": {"type": "array", "items": {"type": "string"}, "description": "本次会话达成的技术架构与设计决议"},
+                        "open_questions": {"type": "array", "items": {"type": "string"}, "description": "下一个 AI 接棒需要关注的未决问题/待办"},
+                        "title": {"type": "string", "description": "交接文档标题 (可选)"}
+                    },
+                    "required": ["project_name", "session_summary"]
+                }
+            },
+            {
+                "name": "get_latest_handoff",
+                "description": "查询获取最新一次的 AI 待办交接信息 (SessionStart 时自动恢复上下文)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project_name": {"type": "string", "description": "项目名称 (可选)"}
+                    }
+                }
+            },
+            {
+                "name": "index_file",
+                "description": "对指定的外部 Markdown 记忆文件建立全文与向量索引",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "Markdown 文件路径"}
+                    },
+                    "required": ["file_path"]
+                }
+            }
+        ]
+
+    def execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """执行具体的 MCP Tool 并返回文本结果"""
+        if tool_name == "search_memory":
+            query = arguments.get("query", "")
+            limit = arguments.get("limit", 5)
+            results = self.service.hybrid_search(query, limit=limit)
+            return json.dumps(results, ensure_ascii=False, indent=2)
+
+        elif tool_name == "save_memory":
+            doc = MemoryDocument(
+                title=arguments.get("title", "Untitled Memory"),
+                content=arguments.get("content", ""),
+                session_summary=arguments.get("session_summary", ""),
+                decisions=arguments.get("decisions", []),
+                open_questions=arguments.get("open_questions", []),
+                project=arguments.get("project", "default"),
+                tags=arguments.get("tags", ["ai-memory"])
+            )
+            saved_path = self.service.save_memory(doc)
+            return json.dumps({"status": "success", "file_path": saved_path, "doc_id": doc.doc_id}, ensure_ascii=False)
+
+        elif tool_name == "create_handoff":
+            p_name = arguments.get("project_name", "default")
+            summary = arguments.get("session_summary", "")
+            decisions = arguments.get("decisions", [])
+            questions = arguments.get("open_questions", [])
+            title = arguments.get("title", "Session Handoff")
+            doc = self.service.create_handoff(p_name, summary, decisions, questions, title=title)
+            return json.dumps({"status": "success", "file_path": doc.file_path, "handoff_id": doc.doc_id}, ensure_ascii=False)
+
+        elif tool_name == "get_latest_handoff":
+            p_name = arguments.get("project_name")
+            res = self.service.get_latest_handoff(project_name=p_name)
+            if not res:
+                return json.dumps({"status": "not_found", "message": "未找到任何交接记录"}, ensure_ascii=False)
+            return json.dumps({"status": "success", "handoff": res}, ensure_ascii=False)
+
+        elif tool_name == "index_file":
+            fp = arguments.get("file_path", "")
+            doc = self.service.index_file(fp)
+            if not doc:
+                return json.dumps({"status": "error", "message": f"文件不存在: {fp}"}, ensure_ascii=False)
+            return json.dumps({"status": "success", "doc_id": doc.doc_id, "title": doc.title}, ensure_ascii=False)
+
+        else:
+            raise ValueError(f"未知工具: {tool_name}")
+
+    def handle_rpc_message(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """处理符合 JSON-RPC 2.0 规范的请求"""
+        req_id = request.get("id")
+        method = request.get("method")
+        params = request.get("params", {})
+
+        if method == "initialize":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "butler-ai-memory", "version": "1.0.0"}
+                }
+            }
+
+        elif method == "notifications/initialized":
+            return None
+
+        elif method == "tools/list":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"tools": self.get_tool_definitions()}
+            }
+
+        elif method == "tools/call":
+            tool_name = params.get("name")
+            arguments = params.get("arguments", {})
+            try:
+                text_result = self.execute_tool(tool_name, arguments)
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "content": [{"type": "text", "text": text_result}]
+                    }
+                }
+            except Exception as e:
+                logger.error(f"执行工具 '{tool_name}' 抛出异常: {e}")
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32603, "message": str(e)}
+                }
+
+        elif method == "ping":
+            return {"jsonrpc": "2.0", "id": req_id, "result": {}}
+
+        else:
+            if req_id is not None:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32601, "message": f"Method not found: {method}"}
+                }
+            return None
+
+    def run_stdio_loop(self):
+        """标准 stdio JSON-RPC 事件循环"""
+        logger.info("Butler AI Memory MCP Server 启动 (STDIO 模式)...")
+        while True:
+            try:
+                line = sys.stdin.readline()
+                if not line:
+                    break
+                line_str = line.strip()
+                if not line_str:
+                    continue
+
+                # 处理可能的前缀 headers (例如 Content-Length)
+                if line_str.startswith("Content-Length:"):
+                    length = int(line_str.split(":")[1].strip())
+                    sys.stdin.readline() # blank line
+                    body = sys.stdin.read(length)
+                    request = json.loads(body)
+                else:
+                    request = json.loads(line_str)
+
+                response = self.handle_rpc_message(request)
+                if response:
+                    out_json = json.dumps(response, ensure_ascii=False)
+                    sys.stdout.write(out_json + "\n")
+                    sys.stdout.flush()
+            except KeyboardInterrupt:
+                break
+            except Exception as e:
+                logger.error(f"STDIO 循环解析错误: {e}")
+
+
+if __name__ == "__main__":
+    server = MCPMemoryServer()
+    server.run_stdio_loop()

--- a/skills/ai_memory/memory_service.py
+++ b/skills/ai_memory/memory_service.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+"""
+AI Memory Service Core Engine
+提供 Markdown 存储、SQLite FTS5 索引、Zvec 向量检索以及 RRF (倒数排名融合) 混合搜索服务。
+"""
+
+import os
+import sqlite3
+import json
+import time
+import datetime
+import logging
+from typing import List, Dict, Any, Optional, Tuple
+
+from skills.ai_memory.data_model import (
+    MemoryDocument,
+    CREATE_MEMORIES_TABLE,
+    CREATE_MEMORIES_FTS_TABLE,
+    CREATE_FTS_TRIGGERS
+)
+from package.core_utils.embedding_utils import get_embedding
+
+try:
+    import zvec
+except ImportError:
+    zvec = None
+
+logger = logging.getLogger("ai_memory_service")
+
+
+class MemoryService:
+    """
+    AI 记忆服务核心引擎：支持项目级隔离与全局备用存储。
+    """
+    def __init__(self, project_root: Optional[str] = None, api_key: Optional[str] = None):
+        self.project_root = project_root or os.getcwd()
+        self.api_key = api_key
+        self.memory_dir = self._resolve_memory_dir()
+        self.db_path = os.path.join(self.memory_dir, "memory.db")
+        self.zvec_dir = os.path.join(self.memory_dir, "zvec_data")
+
+        os.makedirs(self.memory_dir, exist_ok=True)
+        self._init_sqlite()
+        self._init_zvec()
+
+    def _resolve_memory_dir(self) -> str:
+        """解析存储路径：优先项目内 .butler-memory，无项目根目录降级至全局 ~/butler-memory"""
+        if self.project_root and os.path.exists(self.project_root):
+            p = os.path.join(self.project_root, ".butler-memory")
+            return p
+        user_home = os.path.expanduser("~")
+        return os.path.join(user_home, "butler-memory")
+
+    def _init_sqlite(self):
+        """初始化 SQLite 数据库与 FTS5 全文索引"""
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        with self.conn:
+            self.conn.execute(CREATE_MEMORIES_TABLE)
+            try:
+                self.conn.execute(CREATE_MEMORIES_FTS_TABLE)
+                for trigger_sql in CREATE_FTS_TRIGGERS.strip().split(";\n\n"):
+                    if trigger_sql.strip():
+                        self.conn.execute(trigger_sql)
+            except sqlite3.OperationalError as e:
+                logger.warning(f"SQLite FTS5 虚拟表建立警告 (可能已存在或未启用 FTS5 扩展): {e}")
+
+    def _init_zvec(self):
+        """初始化 Zvec 嵌入式向量数据库"""
+        self.zvec_collection = None
+        self.zvec_enabled = False
+        if not zvec:
+            logger.info("未安装 zvec，系统将降级为纯 SQLite FTS5 混合全文检索。")
+            return
+
+        try:
+            os.makedirs(self.zvec_dir, exist_ok=True)
+            schema = zvec.CollectionSchema(
+                name="ai_memory_zvec",
+                vectors=zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 1024),
+                fields=[
+                    zvec.FieldSchema("doc_id", zvec.DataType.STRING),
+                    zvec.FieldSchema("title", zvec.DataType.STRING),
+                    zvec.FieldSchema("project", zvec.DataType.STRING),
+                    zvec.FieldSchema("file_path", zvec.DataType.STRING),
+                    zvec.FieldSchema("content", zvec.DataType.STRING),
+                    zvec.FieldSchema("timestamp", zvec.DataType.DOUBLE)
+                ]
+            )
+            self.zvec_collection = zvec.create_and_open(path=self.zvec_dir, schema=schema)
+            self.zvec_enabled = True
+            logger.info("Zvec 向量数据库初始化成功。")
+        except Exception as e:
+            logger.warning(f"Zvec 向量库初始化失败 ({e})，降级为 SQLite FTS5。")
+            self.zvec_enabled = False
+
+    def save_memory(self, doc: MemoryDocument) -> str:
+        """
+        保存记忆文档：
+        1. 写入 Markdown 源文件
+        2. 索引至 SQLite & FTS5
+        3. 嵌入生成并存入 Zvec (若可用)
+        """
+        now_str = datetime.datetime.now().strftime("%Y-%m-%d")
+        safe_title = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in doc.title)[:40]
+        filename = f"{now_str}-{safe_title}.md"
+        file_path = os.path.join(self.memory_dir, filename)
+
+        doc.file_path = file_path
+        markdown_text = doc.to_frontmatter_markdown()
+
+        # 1. 保存 Markdown 文件
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(markdown_text)
+
+        # 2. 索引至 SQLite
+        self._save_doc_to_sqlite(doc)
+
+        # 3. 保存至 Zvec
+        self._save_doc_to_zvec(doc)
+
+        return file_path
+
+    def index_file(self, file_path: str) -> Optional[MemoryDocument]:
+        """读取外部 Markdown 文件并建立索引"""
+        if not os.path.exists(file_path):
+            return None
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw_content = f.read()
+
+        doc = MemoryDocument.from_markdown(raw_content, file_path=file_path)
+        self._save_doc_to_sqlite(doc)
+        self._save_doc_to_zvec(doc)
+        return doc
+
+    def index_all_files(self) -> int:
+        """索引记忆目录下的所有 .md 文件"""
+        count = 0
+        for root, _, files in os.walk(self.memory_dir):
+            for file in files:
+                if file.endswith(".md"):
+                    fp = os.path.join(root, file)
+                    self.index_file(fp)
+                    count += 1
+        return count
+
+    def _save_doc_to_sqlite(self, doc: MemoryDocument):
+        """保存/更新 SQLite 记录"""
+        decisions_json = json.dumps(doc.decisions, ensure_ascii=False)
+        questions_json = json.dumps(doc.open_questions, ensure_ascii=False)
+        tags_json = json.dumps(doc.tags, ensure_ascii=False)
+
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT OR REPLACE INTO memories (
+                id, title, project, file_path, content, session_summary, decisions, open_questions, tags, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        """, (
+            doc.doc_id, doc.title, doc.project, doc.file_path, doc.content,
+            doc.session_summary, decisions_json, questions_json, tags_json
+        ))
+        self.conn.commit()
+
+    def _save_doc_to_zvec(self, doc: MemoryDocument):
+        """生成 embedding 并写入 Zvec"""
+        if not self.zvec_enabled or not self.zvec_collection:
+            return
+
+        try:
+            full_text = f"{doc.title}\n{doc.session_summary}\n{' '.join(doc.decisions)}\n{doc.content}"
+            emb = get_embedding(full_text, self.api_key, offline=(self.api_key is None))
+            if emb is not None:
+                zdoc = zvec.Doc(
+                    id=doc.doc_id,
+                    vectors={"embedding": emb.tolist()},
+                    fields={
+                        "doc_id": doc.doc_id,
+                        "title": doc.title,
+                        "project": doc.project,
+                        "file_path": doc.file_path or "",
+                        "content": doc.content,
+                        "timestamp": time.time()
+                    }
+                )
+                self.zvec_collection.insert([zdoc])
+        except Exception as e:
+            logger.warning(f"写入 Zvec 索引失败: {e}")
+
+    def fts_search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """SQLite FTS5 全文搜索"""
+        cursor = self.conn.cursor()
+        clean_query = "".join(c if c.isalnum() or c.isspace() else " " for c in query).strip()
+        results = []
+
+        if clean_query:
+            try:
+                sql = """
+                    SELECT m.id, m.title, m.project, m.file_path, m.content, m.session_summary,
+                           m.decisions, m.open_questions, m.tags, m.created_at, bm25(memories_fts) as score
+                    FROM memories_fts
+                    JOIN memories m ON m.rowid = memories_fts.rowid
+                    WHERE memories_fts MATCH ?
+                    ORDER BY score ASC
+                    LIMIT ?
+                """
+                cursor.execute(sql, (clean_query, limit))
+                rows = cursor.fetchall()
+                for r in rows:
+                    results.append({
+                        "id": r[0], "title": r[1], "project": r[2], "file_path": r[3],
+                        "content": r[4], "session_summary": r[5],
+                        "decisions": json.loads(r[6] or "[]"),
+                        "open_questions": json.loads(r[7] or "[]"),
+                        "tags": json.loads(r[8] or "[]"),
+                        "created_at": r[9],
+                        "score": -float(r[10]) # bm25 lower is better
+                    })
+            except Exception as e:
+                logger.warning(f"FTS5 检索异常，退回 LIKE 模糊搜素: {e}")
+
+        if not results:
+            sql = """
+                SELECT id, title, project, file_path, content, session_summary,
+                       decisions, open_questions, tags, created_at
+                FROM memories
+                WHERE title LIKE ? OR content LIKE ? OR session_summary LIKE ?
+                LIMIT ?
+            """
+            pat = f"%{query}%"
+            cursor.execute(sql, (pat, pat, pat, limit))
+            rows = cursor.fetchall()
+            for r in rows:
+                results.append({
+                    "id": r[0], "title": r[1], "project": r[2], "file_path": r[3],
+                    "content": r[4], "session_summary": r[5],
+                    "decisions": json.loads(r[6] or "[]"),
+                    "open_questions": json.loads(r[7] or "[]"),
+                    "tags": json.loads(r[8] or "[]"),
+                    "created_at": r[9],
+                    "score": 1.0
+                })
+
+        return results
+
+    def vector_search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Zvec 向量语义搜索"""
+        if not self.zvec_enabled or not self.zvec_collection:
+            return []
+
+        try:
+            emb = get_embedding(query, self.api_key, offline=(self.api_key is None))
+            if emb is None:
+                return []
+            vq = zvec.VectorQuery(field_name="embedding", vector=emb.tolist())
+            zres = self.zvec_collection.query(vectors=vq, topk=limit)
+            doc_ids = [d.id for d in zres]
+
+            if not doc_ids:
+                return []
+
+            placeholders = ",".join(["?"] * len(doc_ids))
+            sql = f"""
+                SELECT id, title, project, file_path, content, session_summary,
+                       decisions, open_questions, tags, created_at
+                FROM memories WHERE id IN ({placeholders})
+            """
+            cursor = self.conn.cursor()
+            cursor.execute(sql, doc_ids)
+            doc_map = {r[0]: r for r in cursor.fetchall()}
+
+            results = []
+            for d in zres:
+                r = doc_map.get(d.id)
+                if r:
+                    results.append({
+                        "id": r[0], "title": r[1], "project": r[2], "file_path": r[3],
+                        "content": r[4], "session_summary": r[5],
+                        "decisions": json.loads(r[6] or "[]"),
+                        "open_questions": json.loads(r[7] or "[]"),
+                        "tags": json.loads(r[8] or "[]"),
+                        "created_at": r[9],
+                        "score": float(d.score)
+                    })
+            return results
+        except Exception as e:
+            logger.warning(f"Zvec 向量搜索失败: {e}")
+            return []
+
+    def hybrid_search(self, query: str, limit: int = 5, k: float = 60.0) -> List[Dict[str, Any]]:
+        """
+        RRF (Reciprocal Rank Fusion) 倒数排名融合混合搜索：
+        RRF_score(d) = sum( 1 / (k + rank(d)) )
+        自动兼容纯 FTS5 降级模式。
+        """
+        fts_items = self.fts_search(query, limit=limit * 2)
+        vec_items = self.vector_search(query, limit=limit * 2)
+
+        rrf_scores: Dict[str, float] = {}
+        item_data: Dict[str, Dict[str, Any]] = {}
+
+        # 累计 FTS5 排名得分
+        for rank, item in enumerate(fts_items):
+            doc_id = item["id"]
+            rrf_scores[doc_id] = rrf_scores.get(doc_id, 0.0) + (1.0 / (k + rank + 1))
+            item_data[doc_id] = item
+
+        # 累计 Vector 排名得分
+        for rank, item in enumerate(vec_items):
+            doc_id = item["id"]
+            rrf_scores[doc_id] = rrf_scores.get(doc_id, 0.0) + (1.0 / (k + rank + 1))
+            if doc_id not in item_data:
+                item_data[doc_id] = item
+
+        # 重新按 RRF 分数从高到低排序
+        sorted_ids = sorted(rrf_scores.keys(), key=lambda x: rrf_scores[x], reverse=True)
+        final_results = []
+        for doc_id in sorted_ids[:limit]:
+            res = item_data[doc_id]
+            res["rrf_score"] = rrf_scores[doc_id]
+            final_results.append(res)
+
+        return final_results
+
+    def create_handoff(
+        self,
+        project_name: str,
+        session_summary: str,
+        decisions: List[str],
+        open_questions: List[str],
+        tags: Optional[List[str]] = None,
+        title: str = "Session Handoff"
+    ) -> MemoryDocument:
+        """生成交接文件并持久化"""
+        doc = MemoryDocument(
+            title=title,
+            project=project_name,
+            session_summary=session_summary,
+            decisions=decisions,
+            open_questions=open_questions,
+            tags=tags or ["handoff", "ai-session"],
+            content=f"# 交接记录: {title}\n\n## 会话摘要\n{session_summary}\n\n## 决议事项\n" +
+                    "\n".join(f"- {d}" for d in decisions) +
+                    "\n\n## 待决问题\n" +
+                    "\n".join(f"- {q}" for q in open_questions)
+        )
+        self.save_memory(doc)
+        return doc
+
+    def get_latest_handoff(self, project_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        """获取最近一次交接文档"""
+        cursor = self.conn.cursor()
+        if project_name:
+            sql = """
+                SELECT id, title, project, file_path, content, session_summary,
+                       decisions, open_questions, tags, created_at
+                FROM memories
+                WHERE project = ? AND (tags LIKE '%handoff%' OR title LIKE '%Handoff%')
+                ORDER BY created_at DESC LIMIT 1
+            """
+            cursor.execute(sql, (project_name,))
+        else:
+            sql = """
+                SELECT id, title, project, file_path, content, session_summary,
+                       decisions, open_questions, tags, created_at
+                FROM memories
+                WHERE tags LIKE '%handoff%' OR title LIKE '%Handoff%'
+                ORDER BY created_at DESC LIMIT 1
+            """
+            cursor.execute(sql)
+
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        return {
+            "id": row[0], "title": row[1], "project": row[2], "file_path": row[3],
+            "content": row[4], "session_summary": row[5],
+            "decisions": json.loads(row[6] or "[]"),
+            "open_questions": json.loads(row[7] or "[]"),
+            "tags": json.loads(row[8] or "[]"),
+            "created_at": row[9]
+        }

--- a/tests/unit/test_ai_memory.py
+++ b/tests/unit/test_ai_memory.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+AI Memory Service Unit & Integration Tests
+测试 Markdown FrontMatter 解析、SQLite FTS5 索引与降级、RRF 混合搜索、交接与 MCP 服务。
+"""
+
+import os
+import shutil
+import tempfile
+import json
+import pytest
+
+from skills.ai_memory.data_model import MemoryDocument
+from skills.ai_memory.memory_service import MemoryService
+from skills.ai_memory.mcp_server import MCPMemoryServer
+from skills.ai_memory import handle_request
+
+
+@pytest.fixture
+def temp_memory_dir():
+    temp_dir = tempfile.mkdtemp(prefix="test_ai_memory_")
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_memory_document_serialization():
+    doc = MemoryDocument(
+        title="Test Design",
+        project="Butler",
+        session_summary="Completed memory architecture",
+        decisions=["Use Markdown as source of truth", "Use SQLite FTS5 + Zvec"],
+        open_questions=["What about vector dimensions?"],
+        tags=["architecture", "ai-memory"],
+        content="## Detailed Context\nThis is a test content string."
+    )
+
+    markdown_text = doc.to_frontmatter_markdown()
+    assert "---" in markdown_text
+    assert "Test Design" in markdown_text
+    assert "Use Markdown as source of truth" in markdown_text
+
+    parsed_doc = MemoryDocument.from_markdown(markdown_text)
+    assert parsed_doc.title == "Test Design"
+    assert parsed_doc.project == "Butler"
+    assert parsed_doc.session_summary == "Completed memory architecture"
+    assert "Use Markdown as source of truth" in parsed_doc.decisions
+    assert "What about vector dimensions?" in parsed_doc.open_questions
+    assert "architecture" in parsed_doc.tags
+    assert "This is a test content string." in parsed_doc.content
+
+
+def test_memory_service_crud_and_fts_search(temp_memory_dir):
+    service = MemoryService(project_root=temp_memory_dir)
+
+    doc = MemoryDocument(
+        title="SQLite FTS5 Strategy",
+        project="TestProject",
+        session_summary="Testing SQLite FTS5 search",
+        decisions=["Use BM25 ranking"],
+        open_questions=[],
+        tags=["sqlite", "search"],
+        content="SQLite FTS5 provides high-performance full-text search capabilities."
+    )
+
+    saved_path = service.save_memory(doc)
+    assert os.path.exists(saved_path)
+    assert saved_path.startswith(temp_memory_dir)
+
+    # Test FTS Search
+    results = service.fts_search("capabilities")
+    assert len(results) >= 1
+    assert results[0]["title"] == "SQLite FTS5 Strategy"
+
+    # Test Hybrid Search with Fallback
+    hybrid_res = service.hybrid_search("FTS5 capabilities", limit=5)
+    assert len(hybrid_res) >= 1
+    assert "SQLite FTS5 Strategy" in [r["title"] for r in hybrid_res]
+
+
+def test_handoff_and_session_lifecycle(temp_memory_dir):
+    service = MemoryService(project_root=temp_memory_dir)
+
+    handoff_doc = service.create_handoff(
+        project_name="ProjectButler",
+        session_summary="Built MCP server and FTS5 layer",
+        decisions=["Implemented MCP JSON-RPC protocol"],
+        open_questions=["Add web UI visualization"],
+        title="Handoff Step 1"
+    )
+
+    assert os.path.exists(handoff_doc.file_path)
+
+    latest = service.get_latest_handoff(project_name="ProjectButler")
+    assert latest is not None
+    assert latest["session_summary"] == "Built MCP server and FTS5 layer"
+    assert "Implemented MCP JSON-RPC protocol" in latest["decisions"]
+
+
+def test_mcp_server_json_rpc(temp_memory_dir):
+    server = MCPMemoryServer(project_root=temp_memory_dir)
+
+    # 1. Initialize
+    init_resp = server.handle_rpc_message({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize"
+    })
+    assert init_resp["result"]["serverInfo"]["name"] == "butler-ai-memory"
+
+    # 2. List tools
+    tools_resp = server.handle_rpc_message({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list"
+    })
+    tool_names = [t["name"] for t in tools_resp["result"]["tools"]]
+    assert "search_memory" in tool_names
+    assert "save_memory" in tool_names
+    assert "create_handoff" in tool_names
+
+    # 3. Call save_memory
+    save_tool_resp = server.handle_rpc_message({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "save_memory",
+            "arguments": {
+                "title": "MCP Test Memory",
+                "content": "Content saved via MCP tool call",
+                "session_summary": "MCP summary",
+                "project": "TestMCP"
+            }
+        }
+    })
+    res_text = save_tool_resp["result"]["content"][0]["text"]
+    res_json = json.loads(res_text)
+    assert res_json["status"] == "success"
+
+    # 4. Call search_memory
+    search_tool_resp = server.handle_rpc_message({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "search_memory",
+            "arguments": {
+                "query": "MCP tool call"
+            }
+        }
+    })
+    search_json = json.loads(search_tool_resp["result"]["content"][0]["text"])
+    assert len(search_json) >= 1
+    assert search_json[0]["title"] == "MCP Test Memory"
+
+
+def test_skill_handle_request_lifecycle(temp_memory_dir):
+    start_res = handle_request("session_start", project_root=temp_memory_dir, project_name="TestProj")
+    assert start_res["status"] == "no_previous_handoff"
+
+    save_res = handle_request(
+        "save",
+        project_root=temp_memory_dir,
+        title="Skill Request Test",
+        content="Testing skill entrypoint",
+        session_summary="Summary test"
+    )
+    assert save_res["status"] == "success"
+
+    end_res = handle_request(
+        "session_end",
+        project_root=temp_memory_dir,
+        project_name="TestProj",
+        session_summary="Finished iteration",
+        decisions=["Tested skill handlers"]
+    )
+    assert end_res["status"] == "handoff_saved"
+
+    restore_res = handle_request("session_start", project_root=temp_memory_dir, project_name="TestProj")
+    assert restore_res["status"] == "handoff_restored"
+    assert restore_res["summary"] == "Finished iteration"


### PR DESCRIPTION
Implemented a self-hosted AI Memory system inspired by ai-memory concepts in HelloEveryboby/Butler. It uses Markdown files with YAML FrontMatter as the primary source of truth, indexed via SQLite FTS5 and Zvec vector database with RRF hybrid search. Includes a standard MCP JSON-RPC 2.0 server for Claude Code/Cursor integration, Butler CLI commands (/memory_save, /memory_query), and session handoff lifecycle hooks.

---
*PR created automatically by Jules for task [338432416236490186](https://jules.google.com/task/338432416236490186) started by @HelloEveryboby*