### PR TITLE
fix(runner): add mutex write lock for concurrent websocket writes

### DIFF
--- a/programs/butler_runner/runner.go
+++ b/programs/butler_runner/runner.go
@@ -119,6 +119,7 @@ var (
 	runnerID     = flag.String("id", "default_runner", "Unique ID for this runner")
 	isSleeping   = false
 	mu           sync.Mutex
+	writeMu      sync.Mutex
 	blackboard   = make(map[string]interface{})
 	vault        = NewVaultEngine()
 	procMgr      *ProcessManager
@@ -361,7 +362,10 @@ func connect() error {
 		RunnerID: *runnerID,
 		Data:     envInfo,
 	}
-	if err := c.WriteJSON(regMsg); err != nil {
+	writeMu.Lock()
+	err = c.WriteJSON(regMsg)
+	writeMu.Unlock()
+	if err != nil {
 		return err
 	}
 
@@ -429,7 +433,9 @@ func connect() error {
 				RunnerID: *runnerID,
 				Token:    *authToken,
 			}
+			writeMu.Lock()
 			c.WriteJSON(metricsMsg)
+			writeMu.Unlock()
 		}()
 	}
 }
@@ -997,8 +1003,8 @@ func sendResp(c *websocket.Conn, status string, data interface{}, errMsg string)
 		Error:    errMsg,
 		RunnerID: *runnerID,
 	}
-	mu.Lock()
-	defer mu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 	if err := c.WriteJSON(resp); err != nil {
 		log.Printf("⚠️ 发送响应失败: %v", err)
 	}
@@ -1012,8 +1018,8 @@ func sendRespWithID(c *websocket.Conn, status string, data interface{}, errMsg s
 		RunnerID:  *runnerID,
 		RequestID: requestID,
 	}
-	mu.Lock()
-	defer mu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 	if err := c.WriteJSON(resp); err != nil {
 		log.Printf("⚠️ 发送响应失败: %v", err)
 	}

--- a/programs/butler_runner/runner_patches.go
+++ b/programs/butler_runner/runner_patches.go
@@ -145,8 +145,8 @@ func sendBatch(conn *websocket.Conn, lines []StreamLine, skillID string) {
 		Token:    *authToken,
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 	conn.WriteJSON(msg)
 }
 
@@ -173,9 +173,9 @@ func initModules() {
 				RunnerID: *runnerID,
 				Token:    *authToken,
 			}
-			mu.Lock()
+			writeMu.Lock()
 			procMgr.conn.WriteJSON(msg)
-			mu.Unlock()
+			writeMu.Unlock()
 		}
 	})
 
@@ -283,9 +283,9 @@ func pushShellOutput(c *websocket.Conn, sessionID string) {
 			Token:     *authToken,
 			RequestID: sessionID,
 		}
-		mu.Lock()
+		writeMu.Lock()
 		c.WriteJSON(msg)
-		mu.Unlock()
+		writeMu.Unlock()
 	}
 }
 


### PR DESCRIPTION
Added a global writeMu sync.Mutex to protect gorilla/websocket connection writes in programs/butler_runner/runner.go and programs/butler_runner/runner_patches.go, preventing concurrent WriteJSON panic errors.

---
*PR created automatically by Jules for task [18367688690335523292](https://jules.google.com/task/18367688690335523292) started by @HelloEveryboby*